### PR TITLE
Add conversion-focused landing homepage

### DIFF
--- a/assets/css/z-home.css
+++ b/assets/css/z-home.css
@@ -1,0 +1,141 @@
+/* Homepage landing — hero, credibility strip, audience CTAs, latest writing.
+   Uses the terminal theme's CSS variables so it adapts to the theme palette. */
+
+.home-hero {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  margin: 1rem 0 2.5rem;
+}
+
+.home-hero__photo {
+  flex: 0 0 auto;
+  width: 160px;
+  height: 160px;
+  object-fit: cover;
+  border: 1px solid color-mix(in srgb, var(--accent) 50%, transparent);
+  border-radius: var(--radius);
+}
+
+.home-hero__eyebrow {
+  margin: 0 0 0.4rem;
+  font-size: calc(var(--font-size) * 0.85);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.home-hero__headline {
+  margin: 0 0 0.6rem;
+  font-size: calc(var(--font-size) * 1.6);
+  line-height: 1.25;
+}
+
+.home-hero__sub {
+  margin: 0;
+  max-width: 60ch;
+  color: color-mix(in srgb, var(--foreground) 80%, var(--background));
+}
+
+/* Credibility strip */
+.proof-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.9rem;
+  padding: 0.9rem 0;
+  margin: 0 0 2.5rem;
+  border-top: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
+}
+
+.proof-strip__label {
+  font-size: calc(var(--font-size) * 0.8);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--comment, color-mix(in srgb, var(--foreground) 55%, var(--background)));
+}
+
+.proof-strip__items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.9rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.proof-strip__items li {
+  font-size: calc(var(--font-size) * 0.85);
+  white-space: nowrap;
+}
+
+.proof-strip__items li::before {
+  content: "";
+}
+
+/* Audience CTAs */
+.home-cta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 0 0 3rem;
+}
+
+.home-cta__card {
+  display: flex;
+  flex-direction: column;
+  padding: 1.2rem;
+  border: 1px solid color-mix(in srgb, var(--foreground) 15%, transparent);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--foreground) 3%, transparent);
+}
+
+.home-cta__card--primary {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+.home-cta__title {
+  margin: 0 0 0.5rem;
+  font-size: calc(var(--font-size) * 1.05);
+}
+
+.home-cta__text {
+  margin: 0 0 1.1rem;
+  flex: 1 1 auto;
+  font-size: calc(var(--font-size) * 0.9);
+  color: color-mix(in srgb, var(--foreground) 80%, var(--background));
+}
+
+.home-cta__link {
+  align-self: flex-start;
+}
+
+/* Latest writing */
+.home-writing__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.home-writing__head h2 {
+  margin: 0;
+}
+
+.home-writing__all {
+  font-size: calc(var(--font-size) * 0.85);
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .home-hero {
+    flex-direction: column;
+    text-align: center;
+    gap: 1.2rem;
+  }
+  .home-hero__sub { margin-inline: auto; }
+  .home-cta__link { align-self: stretch; text-align: center; }
+}

--- a/data/home.toml
+++ b/data/home.toml
@@ -1,0 +1,41 @@
+# Homepage hero + landing content.
+# Edit freely — consumed by layouts/index.html. No template changes needed.
+
+headline = "I help blockchain & AI founders ship systems that survive adversarial conditions."
+subheadline = "Security researcher, investor and builder. I audit the code, run the technical diligence, and back the teams building trust-minimized infrastructure."
+
+# Portrait shown in the hero. Lives in static/images/.
+photo = "/images/me.png"
+photoAlt = "Daniel Luca"
+
+# Credibility strip — names of notable audits, employers and stages.
+proof = [
+  "Uniswap",
+  "Aave",
+  "Filecoin",
+  "Polygon",
+  "ConsenSys Diligence",
+  "Eden Block",
+  "DEF CON",
+  "Code Is Law",
+]
+
+# Audience-routed calls to action. `primary = true` highlights the main one.
+[[cta]]
+title = "Need a security review?"
+text = "Smart-contract audits and adversarial code review for protocols that can't afford to be wrong."
+label = "Request an audit"
+url = "https://www.linkedin.com/in/luca-daniel-5227267/"
+primary = true
+
+[[cta]]
+title = "Raising or building?"
+text = "Research-driven technical diligence and hands-on support via Eden Block."
+label = "Get in touch"
+url = "https://x.com/cleanunicorn"
+
+[[cta]]
+title = "Want to follow my work?"
+text = "Essays on security, EVM internals and applied AI — plus talks and podcasts."
+label = "Read the writing"
+url = "/posts/"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,71 @@
+{{ define "main" }}
+  {{ $home := $.Site.Data.home }}
+
+  <section class="home-hero">
+    {{ with $home.photo }}
+      <img class="home-hero__photo" src="{{ . | absURL }}" alt="{{ $home.photoAlt | default $.Site.Title }}" width="160" height="160" loading="eager">
+    {{ end }}
+    <div class="home-hero__body">
+      <p class="home-hero__eyebrow">{{ $.Site.Params.Subtitle }}</p>
+      <h1 class="home-hero__headline">{{ $home.headline | default $.Site.Title }}</h1>
+      {{ with $home.subheadline }}
+        <p class="home-hero__sub">{{ . }}</p>
+      {{ end }}
+    </div>
+  </section>
+
+  {{ with $home.proof }}
+    <section class="proof-strip" aria-label="Selected audits and affiliations">
+      <span class="proof-strip__label">Trusted on</span>
+      <ul class="proof-strip__items">
+        {{ range . }}
+          <li>{{ . }}</li>
+        {{ end }}
+      </ul>
+    </section>
+  {{ end }}
+
+  {{ with $home.cta }}
+    <section class="home-cta" aria-label="Ways to work together">
+      {{ range . }}
+        <div class="home-cta__card{{ if .primary }} home-cta__card--primary{{ end }}">
+          <h2 class="home-cta__title">{{ .title }}</h2>
+          <p class="home-cta__text">{{ .text }}</p>
+          <a class="home-cta__link button inline" href="{{ .url }}">{{ .label }} &rarr;</a>
+        </div>
+      {{ end }}
+    </section>
+  {{ end }}
+
+  {{ if .Content }}
+    <div class="index-content">{{ .Content }}</div>
+  {{ end }}
+
+  <section class="home-writing">
+    <div class="home-writing__head">
+      <h2>Latest writing</h2>
+      <a class="home-writing__all" href="{{ "posts/" | absLangURL }}">All posts &rarr;</a>
+    </div>
+    <div class="posts">
+      {{ $posts := where $.Site.RegularPages "Type" "posts" }}
+      {{ range first 3 $posts }}
+        <article class="post on-list">
+          <h3 class="post-title">
+            <a href="{{ .Permalink }}">{{ .Title | markdownify }}</a>
+          </h3>
+          <div class="post-meta">
+            {{- if .Date -}}
+              <time class="post-date">{{- partial "post-date" . -}}</time>
+            {{- end -}}
+          </div>
+          <div class="post-content">
+            {{ if .Description }}<p>{{ .Description | markdownify }}</p>{{ else }}{{ .Summary }}{{ end }}
+          </div>
+          <div>
+            <a class="read-more button inline" href="{{ .RelPermalink }}">[{{ $.Site.Params.ReadMore }}]</a>
+          </div>
+        </article>
+      {{ end }}
+    </div>
+  </section>
+{{ end }}


### PR DESCRIPTION
## What & why

The homepage currently renders a bare reverse-chronological list of blog posts. A first-time visitor never learns who you are, what you offer, or what to do next — the most valuable real estate on the site does no selling.

This PR replaces it with a **landing page that answers who / what / proof / next-action above the fold**, while keeping the blog discoverable.

## Changes

- **Hero** — value-prop headline, subtitle eyebrow, and your portrait (`static/images/me.png`).
- **Credibility strip** — Uniswap · Aave · Filecoin · Polygon · ConsenSys Diligence · Eden Block · DEF CON · Code Is Law.
- **Three audience-routed CTAs** — security review, investment/partnership, and writing — each pointing to a real channel (LinkedIn, X, `/posts/`).
- **"Latest writing"** teaser (3 most recent posts) so the blog stays one click away.

## How it's built

- Copy and CTAs are **data-driven** via `data/home.toml` — edit text/links without touching templates.
- `layouts/index.html` overrides the theme's home template (theme untouched).
- Styling in `assets/css/z-home.css` reuses the terminal theme's CSS variables (palette, accent, radius) so it looks native; responsive down to mobile.

## Notes

- No public email is used — CTAs route through LinkedIn/X per your preference.
- Verified with a local `hugo` build (theme submodule + Hugo 0.140.2): hero, strip, 3 CTAs (1 primary), 8 proof items, and 3 latest posts all render; CSS is bundled and linked.

https://claude.ai/code/session_01WRzinRq5bcJtEFPmxnprPV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRzinRq5bcJtEFPmxnprPV)_