### PR TITLE
Add Connect/Contact page, nav entry and footer social links

### DIFF
--- a/assets/css/z-contact.css
+++ b/assets/css/z-contact.css
@@ -1,0 +1,35 @@
+/* Sitewide "Connect" footer block (layouts/partials/extended_footer.html). */
+
+.connect-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 1rem;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
+}
+
+.connect-footer__label {
+  font-size: calc(var(--font-size) * 0.8);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: color-mix(in srgb, var(--foreground) 55%, var(--background));
+}
+
+.connect-footer__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.connect-footer__links li::before {
+  content: "";
+}
+
+.connect-footer__links a {
+  font-size: calc(var(--font-size) * 0.85);
+}

--- a/content/contact.md
+++ b/content/contact.md
@@ -1,0 +1,33 @@
++++
+title = "Connect"
+draft = false
+slug = "contact"
+description = "Get in touch with Daniel Luca — smart-contract audits, technical diligence, investment, speaking and collaboration."
+showFullContent = true
++++
+
+I'm always happy to talk to people building serious things in blockchain, security and AI. The fastest way to reach me is a DM on X or a message on LinkedIn — pick whichever fits.
+
+## I'd love to hear from you if…
+
+### You need a security review
+You're shipping a smart-contract system and want an experienced adversarial eye on it before it holds real value. I've audited protocols including [Uniswap](https://uniswap.org/), [Aave](https://aave.com/), [Filecoin](https://filecoin.io/) and [Polygon](https://polygon.technology/).
+
+→ Best via [LinkedIn](https://www.linkedin.com/in/luca-daniel-5227267/) or [X / Twitter](https://x.com/cleanunicorn).
+
+### You're raising or building
+You're a founder working on trust-minimized infrastructure, decentralized AI or security tooling and want technical diligence or a partner who goes beyond the first check. I do this as Technical Partner at [Eden Block](https://edenblock.com).
+
+→ Best via [X / Twitter](https://x.com/cleanunicorn) or [LinkedIn](https://www.linkedin.com/in/luca-daniel-5227267/).
+
+### You want me to speak or come on a podcast
+I enjoy talking about EVM internals, exploits, and applied AI. See some [past talks and podcasts](/about/#talks).
+
+→ Reach out on [X / Twitter](https://x.com/cleanunicorn).
+
+## Find me
+
+- [X / Twitter](https://x.com/cleanunicorn)
+- [LinkedIn](https://www.linkedin.com/in/luca-daniel-5227267/)
+- [GitHub](https://github.com/cleanunicorn)
+- [Download CV (PDF)](/cv.pdf)

--- a/hugo.toml
+++ b/hugo.toml
@@ -16,7 +16,7 @@ pagination.pagerSize = 5
 
 [params]
   contentTypeName = "about"
-  showMenuItems = 3
+  showMenuItems = 4
   fullWidthTheme = false
   centerTheme = true
   autoCover = true
@@ -52,3 +52,8 @@ pagination.pagerSize = 5
         name = "Posts"
         url = "/posts/"
         weight = 30
+      [[languages.en.menu.main]]
+        identifier = "contact"
+        name = "Contact"
+        url = "/contact/"
+        weight = 40

--- a/layouts/partials/extended_footer.html
+++ b/layouts/partials/extended_footer.html
@@ -1,0 +1,9 @@
+<div class="connect-footer">
+  <span class="connect-footer__label">Connect</span>
+  <ul class="connect-footer__links">
+    <li><a href="https://x.com/cleanunicorn" target="_blank" rel="me noopener">X / Twitter</a></li>
+    <li><a href="https://www.linkedin.com/in/luca-daniel-5227267/" target="_blank" rel="me noopener">LinkedIn</a></li>
+    <li><a href="https://github.com/cleanunicorn" target="_blank" rel="me noopener">GitHub</a></li>
+    <li><a href="{{ "contact/" | absLangURL }}">Contact</a></li>
+  </ul>
+</div>


### PR DESCRIPTION
## What & why

Today the only way to reach you is four links buried at the bottom of the About page. There's no contact page, no nav entry, and no persistent way to connect. This PR gives visitors an obvious, audience-aware path to get in touch.

## Changes

- **New `/contact/` page** ("Connect") that routes the three main enquiry types to the right channel:
  - *Need a security review* → LinkedIn / X (with your audit track record)
  - *Raising or building* → X / LinkedIn (via Eden Block)
  - *Speaking / podcasts* → X, linking your talks
  - A plain "Find me" list (X, LinkedIn, GitHub, CV)
- **"Contact" added to the main navigation** — `showMenuItems` bumped `3 → 4` so it shows without collapsing under "Show more".
- **Sitewide "Connect" footer block** (via `layouts/partials/extended_footer.html`) with X, LinkedIn, GitHub and Contact links, styled to match the theme.

## Notes

- Per your preference: **no public email, no booking link, no newsletter** — everything routes through X / LinkedIn / GitHub.
- Verified with a local `hugo` build: `/contact/` renders, "Contact" appears in nav, the footer block and its CSS are present on every page.

https://claude.ai/code/session_01WRzinRq5bcJtEFPmxnprPV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRzinRq5bcJtEFPmxnprPV)_