### PR TITLE
Curate About and Work for signal over volume

### DIFF
--- a/content/about/about.md
+++ b/content/about/about.md
@@ -20,6 +20,15 @@ This deep technical foundation eventually pulled me into **venture capital**, wh
 
 ---
 
+## Highlights
+
+- **Featured in [Code Is Law (2025)](https://www.imdb.com/title/tt35931420/)** — a feature documentary on the DAO hack, the Indexed Finance heist and the "code is law" philosophy in crypto.
+- **Audited some of Ethereum's most-used protocols** — including [Uniswap](https://uniswap.org/), [Aave](https://aave.com/), [Filecoin](https://filecoin.io/) and [Polygon](https://polygon.technology/) — at [ConsenSys Diligence](https://diligence.consensys.net/).
+- **Technical Partner at [Eden Block](https://edenblock.com)**, an early-stage venture firm backing blockchain, Web3 infrastructure and decentralized AI.
+- **Spoke at [DEF CON 27](https://youtu.be/Qd9ubry-c_M), [EthCC](https://youtu.be/ZPoqwAbMWTE) and [ETHPrague](https://youtu.be/WUm34CV2s1I)** on exploits, honeypots and developer experience in Web3.
+
+---
+
 ## Work
 
 [List of employers and startups]({{< relref "previous-work.md" >}})
@@ -56,61 +65,36 @@ Or I am invited to podcasts:
 
 ---
 
-## Featured In
-
-- [Code Is Law (2025)](https://www.imdb.com/title/tt35931420/) — documentary on the DAO hack, Indexed Finance heist and the "code is law" philosophy in crypto.
-
----
-
 ## Projects
 
-### [AtlasPA](https://github.com/cleanunicorn/atlasPA)
-AI powered personal assistant for private use.
-
-### [drove](https://github.com/cleanunicorn/drove)
-llama.cpp server manager, chat interface, observability proxy and model manager.
-
-### [Rag-brain](https://github.com/cleanunicorn/rag-brain)
-Portable private AI memory built as a vector database and MCP server, easily pluggable into chatbots.
-
-### [Quill](https://github.com/cleanunicorn/quill)
-Command-line tool for transcribing audio files, YouTube videos, and podcasts using Faster Whisper.
-
-### [Karl](https://github.com/cleanunicorn/karl)
-Monitors smart contracts deployed on the Ethereum network and tests against vulnerabilities with Mythril. Reduces false positives by forking the blockchain and testing the exploit.
+A few things I'm proud of. There's more on [GitHub](https://github.com/cleanunicorn).
 
 ### [RL-Swarm Smart Contracts](https://github.com/gensyn-ai/rl-swarm-contracts)
-This repository contains the smart contracts for the [Reinforcement Learning Swarm](https://www.gensyn.ai/RLSwarm) for [Gensyn](https://www.gensyn.ai/)'s first public launch with a project which lets anyone, anywhere, join and participate in a distributed reinforcement learning system that learns faster together than alone.
+The smart contracts powering [Gensyn](https://www.gensyn.ai/)'s [RL Swarm](https://www.gensyn.ai/RLSwarm) — a distributed reinforcement-learning system that lets anyone, anywhere, join and train models that learn faster together than alone. Built for their first public launch.
 
-### [Multistream](https://github.com/cleanunicorn/multistream)
-A Node.js RTMP server that receives streams from OBS and restreams them to multiple platforms simultaneously like Twitch, YouTube, Kick. Has features to automatically record and transcribe, identifies clippable moments and helps generate short clips.
+### [Karl](https://github.com/cleanunicorn/karl)
+My security research, productized: it monitors live Ethereum smart contracts and tests them against vulnerabilities with Mythril, forking the chain to confirm real exploits and cut false positives.
 
-### [Ethereum Smart Contract Template](https://github.com/cleanunicorn/ethereum-smartcontract-template)
-This development quick start template is heavily inspired by [Georgios's template](https://github.com/gakonst/dapptools-template). Over time it was migrated to use [foundry](https://github.com/gakonst/foundry) since dapptools was deprecated.
+### [drove](https://github.com/cleanunicorn/drove)
+Local LLM infrastructure in one tool — a llama.cpp server manager, chat interface, observability proxy and model manager.
 
-### [Hitomi](https://github.com/cleanunicorn/hitomi)
-Yet another Ethereum web3 console for any node.
+### [Rag-brain](https://github.com/cleanunicorn/rag-brain)
+Portable, private AI memory: a vector database and MCP server you can plug into any chatbot.
 
-### [Santoku](https://github.com/cleanunicorn/santoku)
-It decodes ABI encoded hex strings into the original types. Try it [here](https://cleanunicorn.github.io/santoku/).
+### More projects
 
-### [Mythos](https://github.com/cleanunicorn/mythos)
-Mythos is a CLI client for the [MythX](https://mythx.io) API.
-
-### [Flaterra](https://github.com/cleanunicorn/flaterra)
-Flaterra parses the provided Solidity source file and adds any other `imported` files. This is useful if you want to upload your source code to a block explorer for verification, use it with [Remix](https://remix.ethereum.org) or to run analysis on it, for example with [MythX](https://mythx.io/) or [Mythril](https://github.com/ConsenSys/mythril-classic/).
-
-### [Midas](https://gitlab.com/cleanunicorn/eth-tipper) 
-A [Discord](https://discordapp.com) bot that acts as an Ethereum wallet and facilitates sending Ether between users.
-
-### [abi2signature](https://github.com/cleanunicorn/abi2signature)
-Generates the Ethereum ABI 4 byte signature.
-
-### [ranploy](https://github.com/cleanunicorn/ranploy)
-Generates the EVM code to deploy the specified runtime bytecode.
-
-### [artifaqt](https://github.com/consensys/artifaqt)
-Social token collectible IRL game part of the [DevCon4](https://devcon4.ethereum.org/) Ethereum conference.
+- [AtlasPA](https://github.com/cleanunicorn/atlasPA) — AI-powered personal assistant for private use.
+- [Quill](https://github.com/cleanunicorn/quill) — CLI tool for transcribing audio files, YouTube videos and podcasts using Faster Whisper.
+- [Multistream](https://github.com/cleanunicorn/multistream) — Node.js RTMP server that restreams OBS to Twitch, YouTube and Kick, with auto-record, transcription and clip detection.
+- [Ethereum Smart Contract Template](https://github.com/cleanunicorn/ethereum-smartcontract-template) — a Foundry-based dapp quick-start, inspired by [Georgios's template](https://github.com/gakonst/dapptools-template).
+- [Hitomi](https://github.com/cleanunicorn/hitomi) — an Ethereum web3 console for any node.
+- [Santoku](https://github.com/cleanunicorn/santoku) — decodes ABI-encoded hex strings into their original types. Try it [here](https://cleanunicorn.github.io/santoku/).
+- [Mythos](https://github.com/cleanunicorn/mythos) — CLI client for the [MythX](https://mythx.io) API.
+- [Flaterra](https://github.com/cleanunicorn/flaterra) — flattens a Solidity file and its `imports` into one source for verification or analysis (Remix, MythX, Mythril).
+- [Midas](https://gitlab.com/cleanunicorn/eth-tipper) — a [Discord](https://discordapp.com) bot that acts as an Ethereum wallet and sends Ether between users.
+- [abi2signature](https://github.com/cleanunicorn/abi2signature) — generates the Ethereum ABI 4-byte signature.
+- [ranploy](https://github.com/cleanunicorn/ranploy) — generates the EVM code to deploy a given runtime bytecode.
+- [artifaqt](https://github.com/consensys/artifaqt) — social token collectible IRL game from the [DevCon4](https://devcon4.ethereum.org/) Ethereum conference.
 
 ---
 

--- a/content/previous-work.md
+++ b/content/previous-work.md
@@ -49,9 +49,9 @@ Founded [Akira Tech](https://github.com/akiratechhq) as a specialized security s
 * **Since** November 2018
 * **Until** August 2020
 
-[ConsenSys Diligence](https://diligence.consensys.net/) does smart contract audits and Ethereum blockchain security. I am part of the team doing security audits and consulting. I also do security research and speak whenever I get the chance.
+As part of [ConsenSys Diligence](https://diligence.consensys.net/) — a leading smart-contract audit and Ethereum security team — I delivered security audits and consulting for some of the most widely used protocols on Ethereum, and pursued security research and conference talks alongside the engagements.
 
-Audited:
+Selected audits:
 - [Uniswap](https://uniswap.org/) - popular DEX (decentralized exchange) platform written in Vyper
 - [Aave](https://aave.com/) - governance and token issuance
 - [Aragon](https://aragon.org/) - multiple apps reviewed
@@ -69,7 +69,7 @@ Audited:
 * **Since** February 2017
 * **Until** November 2018
 
-Alethio is a ConsenSys spoke which creates analytics for the Ethereum blockchain. I've built most of the data pipeline from that extracts the blockchain data, applied an [ontology](https://ethon.consensys.net/) and imported into multiple databases.
+Alethio was a ConsenSys spoke building analytics for the Ethereum blockchain. I built most of the data pipeline that extracts on-chain data, applies an [ontology](https://ethon.consensys.net/) and imports it into multiple databases — the foundation powering Alethio's analytics products.
 
 
 ---


### PR DESCRIPTION
## What & why

The About page has A-tier credibility (Code Is Law, marquee audits) buried *below* a ~20-item project dump and long lists, which dilutes the signal. This PR leads with the strongest material and curates the rest.

## Changes

**About**
- New **"Highlights"** block directly under the intro, surfacing the four strongest signals immediately: featured in *Code Is Law (2025)*, audited Uniswap / Aave / Filecoin / Polygon, Technical Partner at Eden Block, and DEF CON / EthCC / ETHPrague talks. (Previously "Featured In" sat near the bottom.)
- **Curated Projects**: 4 flagship entries — RL-Swarm (Gensyn), Karl, drove, Rag-brain — each with a one-line "why it matters", with everything else collapsed into a compact **"More projects"** list. Same projects, far better hierarchy.

**Work**
- Reframed **ConsenSys Diligence** and **Alethio** around outcomes and scope instead of duties ("Selected audits", "the foundation powering Alethio's analytics products"). Truthful rewording only — no invented metrics.

## Side effect (intended)

The CV generator keys projects off `### [name](url)` headings, so `static/cv.html` now lists **only the four flagship projects** — a tighter, more recruiter-friendly resume. Verified locally: the CV renders the flagship four and the "More projects" bullets are excluded.

> Merge-order note: this PR edits the body of `content/about/about.md`. The SEO PR (#6) renames that file to `_index.md`. The edits are in different regions (body vs frontmatter) so git rename detection should merge them cleanly; if both are open, merging #6 first keeps it trivial.

https://claude.ai/code/session_01WRzinRq5bcJtEFPmxnprPV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRzinRq5bcJtEFPmxnprPV)_