### PR TITLE
Add visual polish layer for a more credible, intentional feel

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,130 @@
+/* Visual polish layer — refines typography, hierarchy and detail on top of
+   the terminal theme. Loaded last (see head.html), so it overrides cleanly.
+   Goal: keep the terminal character, read as more intentional and credible. */
+
+:root {
+  --measure: 46rem;        /* comfortable reading width */
+  --muted: color-mix(in srgb, var(--foreground) 62%, var(--background));
+  --hairline: color-mix(in srgb, var(--foreground) 14%, transparent);
+}
+
+/* --- Typographic hierarchy -------------------------------------------- */
+
+h1, h2, h3, h4, h5, h6 {
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+}
+
+h1 { font-size: calc(var(--font-size) * 1.7); }
+h2 { font-size: calc(var(--font-size) * 1.32); margin-top: 2.2rem; }
+h3 { font-size: calc(var(--font-size) * 1.12); }
+
+/* Subtle accent tick before top-level section headings */
+.content h2::before {
+  content: "";
+  display: inline-block;
+  width: 0.7em;
+  height: 0.12em;
+  margin-right: 0.5em;
+  vertical-align: middle;
+  background: var(--accent);
+}
+
+/* Keep auto-generated/listing titles and post titles clean (no tick) */
+.post-title::before,
+.home-writing__head h2::before,
+.proof-strip__label::before { content: none !important; }
+
+p { line-height: 1.7; }
+
+/* Constrain prose measure on text pages for readability */
+.post-content p,
+.index-content p,
+.post-content ul,
+.post-content ol {
+  max-width: var(--measure);
+}
+
+/* --- Links ------------------------------------------------------------ */
+
+.content a {
+  text-underline-offset: 0.18em;
+  text-decoration-thickness: 1px;
+  transition: color 0.12s ease, text-decoration-color 0.12s ease;
+}
+
+.content a:hover {
+  text-decoration-color: var(--accent);
+}
+
+/* --- Logo / header ---------------------------------------------------- */
+
+.logo {
+  letter-spacing: 0.02em;
+  padding: 5px 12px;
+}
+
+/* --- Rules, quotes, lists -------------------------------------------- */
+
+hr {
+  border: 0;
+  height: 1px;
+  background: var(--hairline);
+  margin: 2.5rem 0;
+}
+
+blockquote {
+  margin: 1.5rem 0;
+  padding: 0.2rem 0 0.2rem 1.1rem;
+  border-left: 2px solid var(--accent);
+  color: var(--muted);
+  font-style: italic;
+}
+
+.content li { margin: 0.3rem 0; }
+
+/* --- Media ------------------------------------------------------------ */
+
+.content img {
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius);
+}
+
+/* --- Tables ----------------------------------------------------------- */
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+th, td {
+  border: 1px solid var(--hairline);
+  padding: 0.5rem 0.7rem;
+  text-align: left;
+}
+
+thead th {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+/* --- Accessibility ---------------------------------------------------- */
+
+a:focus-visible,
+button:focus-visible,
+.button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--radius);
+}
+
+::selection {
+  background: color-mix(in srgb, var(--accent) 85%, var(--background));
+  color: var(--background);
+}
+
+/* --- Post meta / dates ------------------------------------------------ */
+
+.post-meta,
+.post-date {
+  color: var(--muted);
+}


### PR DESCRIPTION
## What & why

The terminal/monospace aesthetic signals "hacker" well — great for the security half of your brand — but a few details read as a default theme rather than a deliberately designed site, which matters when a founder or LP is sizing you up. This PR layers tasteful refinements **without abandoning the terminal character**.

## Approach

All changes live in `static/style.css`, which the theme loads **last** (after its own CSS and `terminal.css`), so it overrides cleanly with no theme edits and no risk to the existing look. It reuses the theme's CSS variables (`--accent`, `--foreground`, `--radius`, …) so it adapts to the palette.

## Changes

- **Hierarchy** — larger, tighter headings; a subtle amber accent tick before section headings (suppressed on listing/post titles).
- **Readability** — constrained prose measure (`46rem`) and looser line-height for body text.
- **Detail** — refined link underline offset/hover, softer hairline `hr`s, accent-bordered blockquotes, bordered images, readable tables.
- **Accessibility** — visible `:focus-visible` outlines and an accent `::selection` colour.
- **Meta** — muted post dates / meta.

## Verification

Local `hugo` build: `style.css` is linked last on every page and deployed to `/style.css`; no build warnings.

> Independent of the other PRs — touches only the new `static/style.css`, so no merge conflicts with the homepage, contact, SEO or content PRs.

https://claude.ai/code/session_01WRzinRq5bcJtEFPmxnprPV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRzinRq5bcJtEFPmxnprPV)_