### PR TITLE
Add on-brand terminal-style 404 page

### DIFF
--- a/assets/css/z-404.css
+++ b/assets/css/z-404.css
@@ -1,0 +1,58 @@
+/* On-brand terminal 404 page (layouts/404.html).
+   Reuses the terminal theme's CSS variables so it adapts to the palette. */
+
+.notfound {
+  margin: 1.5rem 0 3rem;
+}
+
+.notfound__shell {
+  margin: 0 0 2rem;
+  padding: 1.1rem 1.2rem;
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--foreground) 4%, transparent);
+  overflow-x: auto;
+  font-size: calc(var(--font-size) * 0.92);
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.notfound__prompt { color: var(--accent); }
+.notfound__path   { color: color-mix(in srgb, var(--foreground) 70%, var(--background)); }
+.notfound__err    { color: #e06c75; }
+
+.notfound__cursor {
+  display: inline-block;
+  margin-left: 0.1em;
+  color: var(--accent);
+  animation: notfound-blink 1.1s steps(1) infinite;
+}
+
+@keyframes notfound-blink {
+  50% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .notfound__cursor { animation: none; }
+}
+
+.notfound__title {
+  margin: 0 0 0.6rem;
+}
+
+.notfound__lede {
+  margin: 0 0 1.6rem;
+  max-width: 56ch;
+  color: color-mix(in srgb, var(--foreground) 80%, var(--background));
+}
+
+.notfound__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 0.8rem;
+}
+
+.notfound__hint {
+  opacity: 0.6;
+  font-size: 0.85em;
+}

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,20 @@
+{{ define "main" }}
+  <section class="notfound" aria-labelledby="notfound-title">
+    <pre class="notfound__shell" aria-hidden="true"><span class="notfound__prompt">visitor@danielluca</span>:<span class="notfound__path">~</span>$ cat {{ .RelPermalink }}
+cat: {{ .RelPermalink }}: <span class="notfound__err">No such file or directory</span>
+
+<span class="notfound__prompt">visitor@danielluca</span>:<span class="notfound__path">~</span>$ trace 404
+  → page never mined, or reorged away
+  → exit status 404<span class="notfound__cursor">&#9608;</span></pre>
+
+    <h1 id="notfound-title" class="notfound__title">404 — block not found</h1>
+    <p class="notfound__lede">{{ $.Site.Params.missingContentMessage | default "The page you're looking for isn't on this chain. Here are some valid entry points:" }}</p>
+
+    <nav class="notfound__links" aria-label="Suggested pages">
+      <a class="button inline" href="{{ "/" | absURL }}">cd ~ <span class="notfound__hint">home</span></a>
+      <a class="button inline" href="{{ "posts/" | absLangURL }}">ls posts <span class="notfound__hint">writing</span></a>
+      <a class="button inline" href="{{ "about/" | absLangURL }}">whoami <span class="notfound__hint">about</span></a>
+      <a class="button inline" href="{{ "contact/" | absLangURL }}">ping me <span class="notfound__hint">contact</span></a>
+    </nav>
+  </section>
+{{ end }}


### PR DESCRIPTION
## What & why

The theme ships a bare 404 ("Page not found... → Back to home"). A dead end is a missed chance to reinforce your brand at the exact moment a visitor would otherwise bounce. This replaces it with a **memorable, on-brand terminal moment** that also routes people to real content.

## Changes

- **`layouts/404.html`** — overrides the theme's 404 with a fake shell session:
  - a failed `cat <bad-path>` → `No such file or directory`
  - a `trace 404` ("page never mined, or reorged away") with a blinking cursor
  - the headline **"404 — block not found"**
  - four command-styled links: `cd ~` (home), `ls posts` (writing), `whoami` (about), `ping me` (contact)
- **`assets/css/z-404.css`** — scoped styling that reuses the theme's CSS variables (`--accent`, `--foreground`, `--radius`), so it matches the amber-on-dark palette. The cursor blink is disabled under `prefers-reduced-motion`.

## Notes

- The headline copy still honors `params.missingContentMessage` if you ever set it.
- Self-contained: only adds two new files, no theme edits, no conflicts with other open work.

## Verification

Local `hugo` build (extended 0.140.2): `/404.html` renders the shell block, headline and four links; `z-404.css` is compiled into the bundled stylesheet.

https://claude.ai/code/session_012h888qNqESaQrFreDtq4Ku

---
_Generated by [Claude Code](https://claude.ai/code/session_012h888qNqESaQrFreDtq4Ku)_