### PR TITLE
Add Schema.org JSON-LD structured data

### DIFF
--- a/layouts/partials/extended_head.html
+++ b/layouts/partials/extended_head.html
@@ -2,4 +2,6 @@
 {{- partial "math.html" . }}
 {{- end }}
 
+{{- partial "structured-data.html" . }}
+
 {{- partial "analytics.html" . }}

--- a/layouts/partials/structured-data.html
+++ b/layouts/partials/structured-data.html
@@ -1,0 +1,68 @@
+{{- /*
+  Schema.org JSON-LD structured data.
+  - WebSite (every page)
+  - Person + ProfilePage (home and /about/)
+  - BlogPosting (single posts)
+  Improves how Google/LinkedIn/X interpret the site and enables rich results.
+  Note: jsonify output must be piped through safeJS, otherwise html/template
+  re-encodes it as a JS string inside the <script> element.
+*/ -}}
+
+{{- $site := .Site -}}
+{{- $author := $site.Params.author | default $site.Title -}}
+{{- $sameAs := slice
+  "https://x.com/cleanunicorn"
+  "https://www.linkedin.com/in/luca-daniel-5227267/"
+  "https://github.com/cleanunicorn"
+  "https://www.imdb.com/title/tt35931420/" -}}
+
+{{- /* Person object reused by Person/ProfilePage and as article author */ -}}
+{{- $person := dict
+  "@type" "Person"
+  "name" $author
+  "alternateName" "CleanUnicorn"
+  "url" ($site.BaseURL | absURL)
+  "image" ("/images/me.png" | absURL)
+  "jobTitle" "Security Researcher & Investor"
+  "description" "Ethereum security auditor, investor and builder working in blockchain since 2017; Technical Partner at Eden Block."
+  "knowsAbout" (slice "Smart Contract Security" "Ethereum" "Solidity" "EVM Internals" "DeFi" "Blockchain Security" "Venture Capital" "Decentralized AI")
+  "sameAs" $sameAs -}}
+
+{{- /* WebSite — every page */ -}}
+{{- $website := dict
+  "@context" "https://schema.org"
+  "@type" "WebSite"
+  "name" $site.Title
+  "url" ($site.BaseURL | absURL)
+  "description" $site.Params.subtitle
+  "inLanguage" $site.Language.Lang
+  "author" $person -}}
+<script type="application/ld+json">{{ $website | jsonify | safeJS }}</script>
+
+{{- if or .IsHome (eq .RelPermalink "/about/") }}
+  {{- $profile := dict
+    "@context" "https://schema.org"
+    "@type" "ProfilePage"
+    "url" .Permalink
+    "mainEntity" $person -}}
+  <script type="application/ld+json">{{ $profile | jsonify | safeJS }}</script>
+{{- end }}
+
+{{- if and .IsPage (eq .Type "posts") }}
+  {{- $img := "og-image.png" | absURL -}}
+  {{- with .Params.cover }}{{ $img = . | absURL }}{{ end -}}
+  {{- $posting := dict
+    "@context" "https://schema.org"
+    "@type" "BlogPosting"
+    "headline" .Title
+    "url" .Permalink
+    "mainEntityOfPage" .Permalink
+    "datePublished" (.Date.Format "2006-01-02")
+    "description" (.Description | default (.Summary | plainify))
+    "image" $img
+    "author" $person
+    "publisher" $person
+    "keywords" (delimit (.Params.keywords | default (slice)) ", ") -}}
+  {{- if not .Lastmod.IsZero }}{{ $posting = merge $posting (dict "dateModified" (.Lastmod.Format "2006-01-02")) }}{{ end -}}
+  <script type="application/ld+json">{{ $posting | jsonify | safeJS }}</script>
+{{- end }}


### PR DESCRIPTION
## What & why

The site has good OG/Twitter cards (PR #6) but **no structured data**. Schema.org JSON-LD is what lets Google build a richer understanding of *who you are* — feeding the knowledge panel, "sameAs" identity links (X, LinkedIn, GitHub, IMDb/Code Is Law), and article rich results. It's invisible to humans and high-leverage for discoverability.

## Changes

- **`layouts/partials/structured-data.html`** (new) emits:
  - **`WebSite`** on every page
  - **`Person` + `ProfilePage`** on the home page and `/about/` — name, `alternateName` "CleanUnicorn", job title, `knowsAbout` (smart-contract security, EVM, DeFi, VC, decentralized AI…), and `sameAs` links to X / LinkedIn / GitHub / the *Code Is Law* IMDb entry
  - **`BlogPosting`** on each post — headline, dates, description, image, author/publisher
- **`layouts/partials/extended_head.html`** — wires the partial in (alongside the existing math + analytics partials).

## Implementation note

`jsonify` output is piped through **`safeJS`**. Without it, Go's `html/template` treats the string as a value in the `<script>` JS context and re-encodes it (wrapping the whole object in quotes and escaping every `"`), producing invalid JSON-LD. `safeJS` marks it as already-safe so it emits verbatim.

## Verification

Local `hugo` build (extended 0.140.2): each page's `<script type="application/ld+json">` blocks **parse as valid JSON** with the expected `@type`s:
- `/` → `WebSite`, `ProfilePage`
- `/about/` → `WebSite`, `ProfilePage`
- a post → `WebSite`, `BlogPosting`

Independent of the other open PRs — only adds a partial and one wiring line.

https://claude.ai/code/session_012h888qNqESaQrFreDtq4Ku

---
_Generated by [Claude Code](https://claude.ai/code/session_012h888qNqESaQrFreDtq4Ku)_