### PR TITLE
Add "by the numbers" credibility band to homepage

### DIFF
--- a/assets/css/z-home.css
+++ b/assets/css/z-home.css
@@ -74,6 +74,40 @@
   content: "";
 }
 
+/* By-the-numbers band */
+.home-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1px;
+  margin: 0 0 3rem;
+  background: color-mix(in srgb, var(--foreground) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.home-stats__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1.1rem 1.2rem;
+  background: var(--background);
+}
+
+.home-stats__value {
+  font-size: calc(var(--font-size) * 1.9);
+  line-height: 1;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.home-stats__label {
+  font-size: calc(var(--font-size) * 0.8);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: color-mix(in srgb, var(--foreground) 70%, var(--background));
+}
+
 /* Audience CTAs */
 .home-cta {
   display: grid;

--- a/data/home.toml
+++ b/data/home.toml
@@ -20,6 +20,24 @@ proof = [
   "Code Is Law",
 ]
 
+# "By the numbers" credibility band. Edit freely — values are intentionally
+# conservative and defensible. Set to an empty list to hide the band.
+[[stats]]
+value = "2017"
+label = "Securing Ethereum since"
+
+[[stats]]
+value = "8+"
+label = "Marquee protocols audited"
+
+[[stats]]
+value = "10+"
+label = "Talks & podcasts"
+
+[[stats]]
+value = "15+"
+label = "Open-source projects"
+
 # Audience-routed calls to action. `primary = true` highlights the main one.
 [[cta]]
 title = "Need a security review?"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -25,6 +25,17 @@
     </section>
   {{ end }}
 
+  {{ with $home.stats }}
+    <section class="home-stats" aria-label="Track record by the numbers">
+      {{ range . }}
+        <div class="home-stats__item">
+          <span class="home-stats__value">{{ .value }}</span>
+          <span class="home-stats__label">{{ .label }}</span>
+        </div>
+      {{ end }}
+    </section>
+  {{ end }}
+
   {{ with $home.cta }}
     <section class="home-cta" aria-label="Ways to work together">
       {{ range . }}


### PR DESCRIPTION
## What & why

The homepage proves credibility with *names* (the "Trusted on" strip). Adding **quantities** gives a fast, scannable sense of depth and longevity — the kind of at-a-glance signal a founder or LP registers in two seconds. This drops a compact stats band between the proof strip and the CTAs.

## The numbers (intentionally conservative)

| Value | Label | Basis |
|------|-------|-------|
| **2017** | Securing Ethereum since | Stated start in blockchain |
| **8+** | Marquee protocols audited | Selected audits: Uniswap, Aave, Aragon, OmiseGo, Polygon, Filecoin, Shell, Horizon |
| **10+** | Talks & podcasts | ~11 listed talks + podcasts on the About page |
| **15+** | Open-source projects | ~16 repos listed under Projects |

No invented metrics — every figure traces to existing site content, and all are rounded *down*.

## How it's built

- Driven entirely by a new `[[stats]]` array in **`data/home.toml`** — edit values/labels (or empty the list to hide the band) with no template changes.
- **`layouts/index.html`** renders the band inside `{{ with $home.stats }}`.
- **`assets/css/z-home.css`** styles it as a hairline grid that reuses the theme's CSS variables; responsive via `auto-fit`.

## Verification

Local `hugo` build (extended 0.140.2): the four tiles render with the values/labels above, and the CSS is compiled into the bundled stylesheet.

Touches only homepage files — no conflict with the 404 or structured-data PRs.

https://claude.ai/code/session_012h888qNqESaQrFreDtq4Ku

---
_Generated by [Claude Code](https://claude.ai/code/session_012h888qNqESaQrFreDtq4Ku)_