### PR TITLE
Make homepage stats linkable

### DIFF
--- a/assets/css/z-home.css
+++ b/assets/css/z-home.css
@@ -108,6 +108,22 @@
   color: color-mix(in srgb, var(--foreground) 70%, var(--background));
 }
 
+.home-stats__item--link {
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.15s ease;
+}
+
+.home-stats__item--link:hover,
+.home-stats__item--link:focus-visible {
+  background: color-mix(in srgb, var(--accent) 8%, var(--background));
+}
+
+.home-stats__item--link:hover .home-stats__label,
+.home-stats__item--link:focus-visible .home-stats__label {
+  color: var(--accent);
+}
+
 /* Audience CTAs */
 .home-cta {
   display: grid;

--- a/data/home.toml
+++ b/data/home.toml
@@ -25,18 +25,22 @@ proof = [
 [[stats]]
 value = "2017"
 label = "Securing Ethereum since"
+url = "/work/"
 
 [[stats]]
 value = "8+"
 label = "Marquee protocols audited"
+url = "/work/#security-researcher-consensys-diligence"
 
 [[stats]]
 value = "10+"
 label = "Talks & podcasts"
+url = "/about/#talks"
 
 [[stats]]
 value = "15+"
 label = "Open-source projects"
+url = "/about/#projects"
 
 # Audience-routed calls to action. `primary = true` highlights the main one.
 [[cta]]

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -28,10 +28,17 @@
   {{ with $home.stats }}
     <section class="home-stats" aria-label="Track record by the numbers">
       {{ range . }}
-        <div class="home-stats__item">
-          <span class="home-stats__value">{{ .value }}</span>
-          <span class="home-stats__label">{{ .label }}</span>
-        </div>
+        {{ if .url }}
+          <a class="home-stats__item home-stats__item--link" href="{{ .url }}">
+            <span class="home-stats__value">{{ .value }}</span>
+            <span class="home-stats__label">{{ .label }}</span>
+          </a>
+        {{ else }}
+          <div class="home-stats__item">
+            <span class="home-stats__value">{{ .value }}</span>
+            <span class="home-stats__label">{{ .label }}</span>
+          </div>
+        {{ end }}
       {{ end }}
     </section>
   {{ end }}


### PR DESCRIPTION
## Summary

The homepage "by the numbers" stats are now clickable, each linking to the page that backs the claim:

| Stat | Links to |
|------|----------|
| Securing Ethereum since **2017** | `/work/` |
| **8+** Marquee protocols audited | `/work/#security-researcher-consensys-diligence` (the "Selected audits" list) |
| **10+** Talks & podcasts | `/about/#talks` |
| **15+** Open-source projects | `/about/#projects` |

## Changes

- **`data/home.toml`** — added a `url` to each stat.
- **`layouts/index.html`** — a stat renders as an `<a>` when it has a `url`, otherwise falls back to the original plain `<div>`, so the data file stays in full control.
- **`assets/css/z-home.css`** — added a `--link` variant that strips the default anchor styling and adds a subtle accent-tinted `:hover`/`:focus-visible` affordance.

## Verification

Ran a clean `hugo` build: all four anchors render with the correct `href`s, and each destination anchor (`id="security-researcher-consensys-diligence"`, `id="talks"`, `id="projects"`, plus the `/work/` page) exists in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)