### PR TITLE
design: refine accent palette, hero presence, and posts list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,5 +50,5 @@ cv-pdf: cv ## Generate CV as PDF into static/ (served by Hugo at /cv.pdf)
 	$$CHROME --headless --disable-gpu --print-to-pdf=$(STATIC_DIR)/cv.pdf --no-margins --no-pdf-header-footer $(STATIC_DIR)/cv.html 2>/dev/null; \
 	echo "PDF written to $(STATIC_DIR)/cv.pdf"
 
-books: ## Refresh the About page Books list from Goodreads (merges with existing). Use ARGS="..." to pass flags.
+books: ## Refresh the About page Books list: top 10 from Goodreads + existing, by rating/popularity. ARGS="--top 12" etc.
 	python3 scripts/update_books.py $(ARGS)

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DATE := $(shell date +"%Y-%m-%dT%H:%M:%S%z")
 
 .DEFAULT_GOAL := help
 
-.PHONY: help serve serve-drafts build build-drafts clean new update-theme submodules cv cv-pdf
+.PHONY: help serve serve-drafts build build-drafts clean new update-theme submodules cv cv-pdf books
 
 help: ## Show this help
 	@awk 'BEGIN {FS = ":.*##"}; /^[a-zA-Z0-9_.-]+:.*?##/ {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -49,3 +49,6 @@ cv-pdf: cv ## Generate CV as PDF into static/ (served by Hugo at /cv.pdf)
 	@which chromium >/dev/null 2>&1 && CHROME=chromium || CHROME=google-chrome; \
 	$$CHROME --headless --disable-gpu --print-to-pdf=$(STATIC_DIR)/cv.pdf --no-margins --no-pdf-header-footer $(STATIC_DIR)/cv.html 2>/dev/null; \
 	echo "PDF written to $(STATIC_DIR)/cv.pdf"
+
+books: ## Refresh the About page Books list from Goodreads (merges with existing). Use ARGS="..." to pass flags.
+	python3 scripts/update_books.py $(ARGS)

--- a/assets/css/z-home.css
+++ b/assets/css/z-home.css
@@ -18,7 +18,7 @@
 }
 
 .home-hero__eyebrow {
-  margin: 0 0 0.4rem;
+  margin: 0 0 0.7rem;
   font-size: calc(var(--font-size) * 0.85);
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -51,14 +51,16 @@
 }
 
 .home-hero__headline {
-  margin: 0 0 0.6rem;
-  font-size: calc(var(--font-size) * 1.6);
-  line-height: 1.25;
+  margin: 0 0 0.85rem;
+  font-size: calc(var(--font-size) * 1.9);
+  line-height: 1.18;
+  letter-spacing: -0.015em;
 }
 
 .home-hero__sub {
   margin: 0;
   max-width: 60ch;
+  line-height: 1.6;
   color: var(--c-text-soft);
 }
 

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -104,19 +104,16 @@ Some of the books I enjoyed:
 <div class="cols">
 <!-- BOOKS:START — managed by scripts/update_books.py via `make books`; edits between the markers are preserved and merged with Goodreads. -->
 
-* **Algorithms to Live By**, by Brian Christian and Tom Griffiths
-* **The Three Body Problem** by Liu Cixin
+* **The Hero of Ages** by Brandon Sanderson
+* **Harry Potter and the Prisoner of Azkaban** by J.K. Rowling
+* **Mistborn: The Final Empire** by Brandon Sanderson
+* **The Name of the Wind** by Patrick Rothfuss
+* **Venture Deals: Be Smarter than Your Lawyer and Venture Capitalist** by Brad Feld
 * **Project Hail Mary** by Andy Weir
-* **Mistborn Series** by Brandon Sanderson
-* **Watchmen** by Alan Moore
-* **Meditations** by Marcus Aurelius
-* **The Sense of Style** by Steven Pinker
-* **The Courage To Be Disliked** by Ichiro Kishimi, Fumitake Koga
-* **Thinking, Fast and Slow** by Daniel Kahneman
-* **Foundation series** by Isaac Asimov
-* **Predictably Irrational** by Dan Ariely
-* **American Gods** by Neil Gaiman
-* **Choose Yourself** by James Altucher
+* **Death's End** by Liu Cixin
+* **The Well of Ascension** by Brandon Sanderson
+* **Harry Potter and the Philosopher's Stone** by J.K. Rowling
+* **Harry Potter and the Chamber of Secrets** by J.K. Rowling
 
 <!-- BOOKS:END -->
 </div>

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -10,12 +10,7 @@ With a deep passion for open-source technologies, security, blockchain and Artif
 
 This deep technical foundation eventually pulled me into **venture capital**, where I now operate at the intersection of blockchain, AI, and security. I focus on research-driven technical due diligence and deal sourcing, utilizing my background as a Blockchain Architect to support founders well beyond the initial check. Whether I am auditing code or evaluating a seed round, **my philosophy remains rooted in open-source technologies and long-term fundamentals**. I am committed to building and backing resilient, secure solutions that drive the industry forward through sound engineering practices.
 
-## Links
-
-- [Twitter / X](https://x.com/cleanunicorn)
-- [GitHub](https://github.com/cleanunicorn)
-- [Linkedin](https://www.linkedin.com/in/luca-daniel-5227267/)
-- [Download CV (PDF)](/cv.pdf)
+**[Download my CV (PDF)](/cv.pdf)** — or find me on [X / Twitter](https://x.com/cleanunicorn), [GitHub](https://github.com/cleanunicorn) and [LinkedIn](https://www.linkedin.com/in/luca-daniel-5227267/).
 
 ---
 
@@ -58,9 +53,9 @@ Sometimes, I give talks about things that I find interesting.
 
 Or I am invited to podcasts:
 
-- [2025 Decentralized Al: The Next Shift - Daniel Luca](https://www.youtube.com/watch?v=ZmzPLI9CJRo)
+- [2025 Decentralized AI: The Next Shift - Daniel Luca](https://www.youtube.com/watch?v=ZmzPLI9CJRo)
 - [2025 The Code Is Law Movie, The DAO and Indexed Finance Heists, Crypto Culture](https://www.youtube.com/watch?v=CTUhbYXopys)
-- [2024 How VCs invests in crypto](https://www.youtube.com/watch?v=SW-UNwZP5LU)
+- [2024 How VCs invest in crypto](https://www.youtube.com/watch?v=SW-UNwZP5LU)
 
 ---
 

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -33,6 +33,8 @@ This deep technical foundation eventually pulled me into **venture capital**, wh
 
 Sometimes, I give talks about things that I find interesting.
 
+<div class="cols">
+
 - [2025 ETHCluj - Beyond "Trust me, bro" Engineering LLM reliability](https://youtu.be/PZtU1BapbJg)
 - [2025 Cypherpunk Congress #1 - The Privacy paradox in AI](https://youtu.be/bz6b6YeM4NM)
 - [2024 NFTBucharest - Decyphering the Bitcoin Ordinals Giant Mess](https://www.youtube.com/watch?v=4ibFG_Do1j0)
@@ -46,6 +48,8 @@ Sometimes, I give talks about things that I find interesting.
 - [BlockchainHackers IV - Mastering Ethereum CTFs](/presentations//blockchainhackers-iv/Mastering-Ethereum-CTFs.pdf)
 - [The Bitcoin Podcast: #283 Daniel Luca - ConsenSys Diligence](https://thebitcoinpodcast.com/the-bitcoin-podcast-283/)
 - [Security Espresso Meetup 0x13 - Ethereum the Hacker's Paradise](https://youtu.be/c-5r4-5rxCA?t=5339)
+
+</div>
 
 ---
 
@@ -97,6 +101,8 @@ Portable, private AI memory: a vector database and MCP server you can plug into 
 I like science fiction, fantasy, comic books, philosophy and psychology.
 Some of the books I enjoyed:
 
+<div class="cols">
+
 * **Algorithms to Live By**, by Brian Christian and Tom Griffiths
 * **The Three Body Problem** by Liu Cixin
 * **Project Hail Mary** by Andy Weir
@@ -110,6 +116,8 @@ Some of the books I enjoyed:
 * **Predictably Irrational** by Dan Ariely
 * **American Gods** by Neil Gaiman
 * **Choose Yourself** by James Altucher
+
+</div>
 
 <!-- ## Conferences
 

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -102,6 +102,7 @@ I like science fiction, fantasy, comic books, philosophy and psychology.
 Some of the books I enjoyed:
 
 <div class="cols">
+<!-- BOOKS:START — managed by scripts/update_books.py via `make books`; edits between the markers are preserved and merged with Goodreads. -->
 
 * **Algorithms to Live By**, by Brian Christian and Tom Griffiths
 * **The Three Body Problem** by Liu Cixin
@@ -117,6 +118,7 @@ Some of the books I enjoyed:
 * **American Gods** by Neil Gaiman
 * **Choose Yourself** by James Altucher
 
+<!-- BOOKS:END -->
 </div>
 
 <!-- ## Conferences

--- a/content/posts/an-extension-of-the-self/index.md
+++ b/content/posts/an-extension-of-the-self/index.md
@@ -6,7 +6,7 @@ authorTwitter = "cleanunicorn" #do not include @
 cover = ""
 # tags = ["ai", "llm", "mcp", "rag", "memory", "vector", "database"]
 keywords = ["ai", "llm", "rag", "memory", "vector", "database"]
-description = ""
+description = "Why today's AI tools suffer from 'digital amnesia' — and how to build portable, private long-term memory you actually own, with a working demo and code."
 showFullContent = false
 readingTime = true
 +++

--- a/content/posts/authenticating-ai-models-in-decentralized-networks:-a-practical-approach/index.md
+++ b/content/posts/authenticating-ai-models-in-decentralized-networks:-a-practical-approach/index.md
@@ -2,6 +2,7 @@
 date = '2024-07-22T14:31:28+01:00'
 draft = false
 title = 'Authenticating AI Models in Decentralized Networks: A Practical Approach'
+description = "Verifying that an AI model is genuine and unaltered in decentralized networks — why watermarking falls short, and how statistical uniqueness does better."
 math = true
 readingTime = true
 +++

--- a/content/posts/eip-7514:-balancing-urgency-with-long-term-vision/index.md
+++ b/content/posts/eip-7514:-balancing-urgency-with-long-term-vision/index.md
@@ -2,6 +2,7 @@
 date = '2023-10-10T13:47:24-03:00'
 draft = false
 title = 'EIP 7514: Balancing Urgency With Long Term Vision'
+description = "Why Ethereum capped validator churn at 8 — trading exponential validator growth for linear, and buying time to scale the client software."
 readingTime = true
 +++
 

--- a/content/posts/how-to-exploit-ethereum-in-a-virtual-environment/index.md
+++ b/content/posts/how-to-exploit-ethereum-in-a-virtual-environment/index.md
@@ -2,6 +2,7 @@
 date = '2019-01-04T12:51:41-03:00'
 draft = false
 title = 'How to Exploit Ethereum in a Virtual Environment'
+description = "How I fork the Ethereum chain to confirm real exploits and filter out honeypots and false positives — the technique behind Karl, my live-contract scanner."
 readingTime = true
 +++
 

--- a/content/posts/making-ais-think-before-they-speak/index.md
+++ b/content/posts/making-ais-think-before-they-speak/index.md
@@ -1,7 +1,8 @@
 +++
 date = '2024-11-30T15:16:12+01:00'
 draft = true
-title = 'Making Ais Think Before They Speak'
+title = 'Making AIs Think Before They Speak'
+description = "Why raw model size isn't enough: what poker and Go AIs reveal about making LLMs plan and reason before they answer."
 readingTime = true
 +++
 

--- a/content/posts/poison-block-explorer-byte-code/index.md
+++ b/content/posts/poison-block-explorer-byte-code/index.md
@@ -2,6 +2,7 @@
 date = '2019-02-11T12:47:55-03:00'
 draft = false
 title = 'Poison Block Explorer Byte Code'
+description = "How an attacker can trick a block explorer into showing harmless bytecode for a malicious contract — a reverted-transaction bug in BlockChair and BlockScout."
 readingTime = true
 +++
 

--- a/content/posts/the-hard-truth---why-distribution-trumps-innovation/index.md
+++ b/content/posts/the-hard-truth---why-distribution-trumps-innovation/index.md
@@ -2,6 +2,7 @@
 date = '2024-09-24T14:55:44+01:00'
 draft = false
 title = 'The Hard Truth - Why Distribution Trumps Innovation'
+description = "The best product rarely wins — the one that reaches the most people does. A look at network effects, distribution and the minority rule."
 readingTime = true
 +++
 

--- a/content/posts/the-inception-of-doppelganger-networks/index.md
+++ b/content/posts/the-inception-of-doppelganger-networks/index.md
@@ -2,6 +2,7 @@
 date = '2024-06-13T14:44:47-03:00'
 draft = false
 title = 'The Inception of Doppelganger Networks'
+description = "A new class of chains that mirror Ethereum but bend its rules — how Shadow's 'free logs' work, and whether Doppelganger Networks are progress or recentralization."
 readingTime = true
 +++
 

--- a/content/posts/the-next-blockchain-bull-run:-user-intents-paving-the-way-for-mass-adoption/index.md
+++ b/content/posts/the-next-blockchain-bull-run:-user-intents-paving-the-way-for-mass-adoption/index.md
@@ -2,6 +2,7 @@
 date = '2023-12-07T14:37:14-03:00'
 draft = false
 title = 'The Next Blockchain Bull Run: User Intents Paving the Way for Mass Adoption'
+description = "Why Intents — declaring the outcome you want, not the exact steps — could abstract away crypto's complexity and unlock the next wave of adoption."
 readingTime = true
 +++
 

--- a/content/posts/the-right-way-to-use-transient-storage-(eip-1153)/index.md
+++ b/content/posts/the-right-way-to-use-transient-storage-(eip-1153)/index.md
@@ -1,7 +1,8 @@
 +++
 date = '2024-02-29T14:23:45+01:00'
 draft = false
-title = 'The Right Way to Use Transient Storage (Eip 1153)'
+title = 'The Right Way to Use Transient Storage (EIP 1153)'
+description = "Transient storage (EIP-1153) cuts gas costs but is easy to misuse — the traps that introduce bugs and widen the attack surface, and how to avoid them."
 readingTime = true
 +++
 

--- a/content/previous-work.md
+++ b/content/previous-work.md
@@ -7,8 +7,7 @@ description = "Daniel Luca's work history — Technical Partner at Eden Block, s
 
 ## Technical Partner, Eden Block
 
-* **Company** Eden Block
-* **Since** November 2022
+*November 2022 – Present*
 
 Technical Partner at [Eden Block](https://edenblock.com) an early-stage venture capital firm focused on blockchain, Web3 infrastructure and Decentralized AI. Provided technical diligence and research for investment decisions, advised portfolio companies on product strategy, software architecture, and security best practices. Collaborated with founders and teams across the portfolio to address technical challenges and drive technology adoption. Helped shape Eden Block’s research-driven investment approach and supported the growth of startups building the foundational layers of the decentralized internet.
 
@@ -27,9 +26,7 @@ Worked closely with portfolio companies such as:
 
 ## Co-Founder, FiatDAO
 
-* **Company** FiatDAO
-* **Since** November 2021
-* **Deployed** April 2022
+*November 2021 · Deployed April 2022*
 
 Co-founded and built [FiatDAO](https://fiatdao.com), a decentralized autonomous organization (DAO) focused on DeFi tools for fixed-income assets on Ethereum. Helped design and build the platform, letting users use their fixed-income positions as collateral to access liquidity and mint stablecoins. Worked on protocol development, governance, and smart contract security, partnering with a global team to launch and improve the product.
 
@@ -37,8 +34,7 @@ Co-founded and built [FiatDAO](https://fiatdao.com), a decentralized autonomous 
 
 ## Founder, Security Researcher, Akira Tech
 
-* **Company** Akira Tech
-* **Since** October 2020
+*October 2020 – Present*
 
 Founded [Akira Tech](https://github.com/akiratechhq) as a specialized security shop with a focus on comprehensive security audits, code reviews, and cyber risk assessments for blockchain and software projects. Led technical engagements with clients, identifying vulnerabilities and recommending actionable solutions to improve system security. Delivered security reports and collaborated with development teams to implement best practices for secure smart contract development.
 
@@ -46,9 +42,7 @@ Founded [Akira Tech](https://github.com/akiratechhq) as a specialized security s
 
 ## Security Researcher, ConsenSys Diligence
 
-* **Company** ConsenSys Diligence
-* **Since** November 2018
-* **Until** August 2020
+*November 2018 – August 2020*
 
 As part of [ConsenSys Diligence](https://diligence.consensys.net/) — a leading smart-contract audit and Ethereum security team — I delivered security audits and consulting for some of the most widely used protocols on Ethereum, and pursued security research and conference talks alongside the engagements.
 
@@ -66,9 +60,7 @@ Selected audits:
 
 ## Developer, Alethio
 
-* **Company** ConsenSys
-* **Since** February 2017
-* **Until** November 2018
+*February 2017 – November 2018 · ConsenSys*
 
 Alethio was a ConsenSys spoke building analytics for the Ethereum blockchain. I built most of the data pipeline that extracts on-chain data, applies an [ontology](https://ethon.consensys.net/) and imports it into multiple databases — the foundation powering Alethio's analytics products.
 
@@ -77,7 +69,7 @@ Alethio was a ConsenSys spoke building analytics for the Ethereum blockchain. I 
 
 ## Blockchain Workshops, Bucharest
 
-* **Since** 2018
+*Since 2018*
 
 Developed and held a series of long format workshops which cover the basics of blockchain, Solidity, EVM, private chains setup, consensus algorithms, smart contract design and other related topics.
 
@@ -85,9 +77,7 @@ Developed and held a series of long format workshops which cover the basics of b
 
 ## Cofounder / CTO, Fitpass
 
-* **Company** Fitpass
-* **Since** May 2016
-* **Until** December 2017
+*May 2016 – December 2017*
 
 Fitpass is platform for fitness studios and classes based in Bucharest, Romania. Cofounded and built the product, backend and frontend.
 
@@ -95,9 +85,7 @@ Fitpass is platform for fitness studios and classes based in Bucharest, Romania.
 
 ## Cofounder / CTO, Lendia
 
-* **Company** Lendia
-* **Since** February 2015
-* **Until** December 2016
+*February 2015 – December 2016*
 
 Lendia was a company aggregating lending offers from multiple banks. Cofounded and built the product.
 
@@ -105,9 +93,7 @@ Lendia was a company aggregating lending offers from multiple banks. Cofounded a
 
 ## Owner, ElasticOrange
 
-* **Company** ElasticOrange
-* **Since** October 2014
-* **Until** January 2017
+*October 2014 – January 2017*
 
 ElasticOrange was a software company that developed products for international clients.
 
@@ -115,9 +101,7 @@ ElasticOrange was a software company that developed products for international c
 
 ## Developer, Filebox
 
-* **Company** Synco Telecom
-* **Since** May 2008
-* **Until** September 2010
+*May 2008 – September 2010 · Synco Telecom*
 
 Filebox was one of the biggest file sharing websites in Romania having 100k uniques per day. We designed the complete software stack, as well as maintained the hardware powering all of it.
 

--- a/data/home.toml
+++ b/data/home.toml
@@ -24,7 +24,7 @@ proof = [
 # conservative and defensible. Set to an empty list to hide the band.
 [[stats]]
 value = "2017"
-label = "Securing Ethereum since"
+label = "Securing Ethereum"
 url = "/work/"
 
 [[stats]]

--- a/data/home.toml
+++ b/data/home.toml
@@ -29,7 +29,7 @@ url = "/work/"
 
 [[stats]]
 value = "8+"
-label = "Marquee protocols audited"
+label = "Protocols audited"
 url = "/work/#security-researcher-consensys-diligence"
 
 [[stats]]

--- a/scripts/generate_cv.py
+++ b/scripts/generate_cv.py
@@ -51,6 +51,13 @@ def md_to_html(md: str) -> str:
             out.append("")
             continue
 
+        # skip standalone block-level HTML wrappers (e.g. layout-only <div>s)
+        if re.match(r"^</?(div|section|aside)\b[^>]*>$", stripped, re.IGNORECASE):
+            if in_ul:
+                out.append("</ul>")
+                in_ul = False
+            continue
+
         # headings
         hm = re.match(r"^(#{1,6})\s+(.*)", stripped)
         if hm:
@@ -150,8 +157,22 @@ def parse_about() -> dict:
     bio_match = re.match(r"^(.*?)(?=^##\s)", body, re.MULTILINE | re.DOTALL)
     bio = bio_match.group(1).strip() if bio_match else ""
 
+    # The intro carries a one-line "Download my CV — or find me on …" row.
+    # Pull the social links out of it for the header, and drop the line from
+    # the bio (a "download this CV" link is meaningless inside the CV itself).
+    contact: list[tuple[str, str]] = []
+    cv_line_re = re.compile(r"^.*Download (?:my )?CV.*$", re.MULTILINE)
+    cv_line = cv_line_re.search(bio)
+    if cv_line:
+        for text, url in re.findall(r"\[([^\]]+)\]\(([^)]+)\)", cv_line.group(0)):
+            if "cv.pdf" in url.lower() or "download" in text.lower():
+                continue
+            contact.append((text, url))
+        bio = cv_line_re.sub("", bio).strip()
+
     return {
         "bio": bio,
+        "contact": contact,
         "talks": extract_section(body, "Talks"),
         "podcasts": extract_section(body, "Podcasts"),
         "projects": extract_section(body, "Projects"),
@@ -292,15 +313,14 @@ def generate_html(output: Path) -> None:
 
     sections = []
 
-    # Bio
+    # Summary / bio
     if about["bio"]:
         sections.append(f'<section class="bio">\n{md_to_html(about["bio"])}\n</section>')
 
-    # Contact / Links — strip the "Download CV" entry (self-referential in the CV)
-    if about["links"]:
-        links_md = re.sub(r"^- \[Download CV.*\n?", "", about["links"], flags=re.MULTILINE)
+    # Work experience — lead with proof
+    if work_md:
         sections.append(
-            f'<section class="links">\n<h2>Contact</h2>\n{md_to_html(links_md)}\n</section>'
+            f'<section class="work">\n<h2>Experience</h2>\n{build_work_html(work_md)}\n</section>'
         )
 
     # Skills
@@ -308,12 +328,6 @@ def generate_html(output: Path) -> None:
     if skills:
         sections.append(
             f'<section class="skills">\n<h2>Skills</h2>\n{build_skills_html(skills)}\n</section>'
-        )
-
-    # Work experience
-    if work_md:
-        sections.append(
-            f'<section class="work">\n<h2>Experience</h2>\n{build_work_html(work_md)}\n</section>'
         )
 
     # Talks
@@ -341,6 +355,14 @@ def generate_html(output: Path) -> None:
 
     body = "\n\n".join(sections)
 
+    # Header contact row — social links pulled from the About intro, plus the site.
+    contact = list(about.get("contact", []))
+    contact.append(("cleanunicorn.github.io", "https://cleanunicorn.github.io"))
+    contact_html = " ".join(
+        f'<a href="{html.escape(url)}">{html.escape(text)}</a>'
+        for text, url in contact
+    )
+
     html_doc = f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -355,6 +377,7 @@ def generate_html(output: Path) -> None:
   <header>
     <h1>{html.escape(config["name"])}</h1>
     <p class="subtitle">{html.escape(config["subtitle"])}</p>
+    <nav class="contact">{contact_html}</nav>
   </header>
 
   <main>

--- a/scripts/update_books.py
+++ b/scripts/update_books.py
@@ -5,21 +5,20 @@ Goodreads retired its public API in 2020, but per-shelf RSS feeds still work:
 
     https://www.goodreads.com/review/list_rss/<USER_ID>?shelf=<SHELF>
 
-This script pulls a shelf (default: the 5-star "favorites" picks from your
-"read" shelf), merges them with the books already curated on the About page,
-de-duplicates, and rewrites the list in place — between the markers:
+This script builds a pool from the books already curated on the About page
+plus a Goodreads shelf, ranks them by your star rating and then the Goodreads
+community average (popularity), and keeps the top N (default 10). Books on the
+page that also appear on Goodreads pick up their ratings, so they rank fairly;
+the list is rewritten in place between the markers:
 
     <!-- BOOKS:START ... -->
     ...
     <!-- BOOKS:END -->
 
-Books you add by hand between those markers are preserved on every run, so the
-result is always "the ones already in the list, plus picks from Goodreads".
-
 Run it only when you want to refresh the list:
 
-    make books                         # default: 5-star books for the configured user
-    python3 scripts/update_books.py --min-rating 4 --limit 30
+    make books                                  # top 10 by rating, then popularity
+    python3 scripts/update_books.py --top 12
     python3 scripts/update_books.py --from-file feed.xml   # offline / behind an allowlist
     python3 scripts/update_books.py --dry-run              # preview, write nothing
 
@@ -42,7 +41,8 @@ ABOUT_MD = ROOT / "content" / "about" / "_index.md"
 
 DEFAULT_USER_ID = "24370112"  # https://www.goodreads.com/user/show/24370112-daniel-luca
 DEFAULT_SHELF = "read"
-DEFAULT_MIN_RATING = 5  # only pull favorites by default
+DEFAULT_TOP = 10
+DEFAULT_MIN_RATING = 0  # 0 = no floor; rank everything and take the top N
 MAX_PAGES = 10
 
 START_RE = re.compile(r"<!--\s*BOOKS:START.*?-->", re.IGNORECASE | re.DOTALL)
@@ -56,18 +56,25 @@ USER_AGENT = "Mozilla/5.0 (compatible; cleanunicorn-cv/1.0; +https://cleanunicor
 # ---------------------------------------------------------------------------
 
 class Book:
-    __slots__ = ("title", "author", "rating", "sort_key")
+    __slots__ = ("title", "author", "rating", "average", "when")
 
-    def __init__(self, title: str, author: str = "", rating: int = 0, sort_key=()):
+    def __init__(self, title: str, author: str = "", rating: int = 0,
+                 average: float = 0.0, when: float = 0.0):
         self.title = title
         self.author = author
-        self.rating = rating
-        self.sort_key = sort_key
+        self.rating = rating      # your own rating, 1–5 (0 if unknown)
+        self.average = average    # Goodreads community average (popularity proxy)
+        self.when = when          # read/added timestamp, for tie-breaking
 
     @property
     def key(self) -> str:
         """Normalised title used for de-duplication."""
         return normalise_title(self.title)
+
+    @property
+    def sort_key(self) -> tuple:
+        # rating first (your favourites), then popularity, then most recent
+        return (-self.rating, -self.average, -self.when)
 
     def to_markdown(self) -> str:
         if self.author:
@@ -77,15 +84,27 @@ class Book:
 
 def normalise_title(title: str) -> str:
     t = title.lower()
-    t = re.sub(r"\s*\([^)]*\)", "", t)   # drop "(Series, #1)" etc.
-    t = re.sub(r"\s*[:\-–—].*$", "", t)  # drop subtitle after : or dash
-    t = re.sub(r"[^a-z0-9]+", " ", t)    # collapse punctuation
+    t = re.sub(r"\s*\([^)]*\)", "", t)        # drop "(Series, #1)" etc.
+    t = re.sub(r"\s*:.*$", "", t)             # drop subtitle after a colon
+    t = re.sub(r"\s+[-–—]\s+.*$", "", t)      # drop subtitle after " - " (keeps hyphenated words)
+    t = re.sub(r"[^a-z0-9]+", " ", t)         # collapse punctuation
     return t.strip()
 
 
 def clean_title(title: str) -> str:
     """Tidy a Goodreads title for display: drop the series parenthetical."""
     return re.sub(r"\s*\([^)]*\)\s*$", "", title).strip()
+
+
+def parse_date(value: str) -> float:
+    """RFC-822 date string -> POSIX timestamp (0.0 if unparseable)."""
+    value = value.strip()
+    if not value:
+        return 0.0
+    try:
+        return parsedate_to_datetime(value).timestamp()
+    except (TypeError, ValueError):
+        return 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -113,36 +132,28 @@ def parse_feed(xml_bytes: bytes) -> list[Book]:
         title = (item.findtext("title") or "").strip()
         if not title:
             continue
-        author = (item.findtext("author_name") or "").strip()
         try:
             rating = int((item.findtext("user_rating") or "0").strip())
         except ValueError:
             rating = 0
+        try:
+            average = float((item.findtext("average_rating") or "0").strip())
+        except ValueError:
+            average = 0.0
         when = parse_date(item.findtext("user_read_at") or item.findtext("user_date_added") or "")
         books.append(
             Book(
                 title=clean_title(title),
-                author=author,
+                author=(item.findtext("author_name") or "").strip(),
                 rating=rating,
-                # higher rating first, then most recently read/added
-                sort_key=(-rating, -when),
+                average=average,
+                when=when,
             )
         )
     return books
 
 
-def parse_date(value: str) -> float:
-    """RFC-822 date string -> POSIX timestamp (0.0 if unparseable)."""
-    value = value.strip()
-    if not value:
-        return 0.0
-    try:
-        return parsedate_to_datetime(value).timestamp()
-    except (TypeError, ValueError):
-        return 0.0
-
-
-def goodreads_books(user_id: str, shelf: str, min_rating: int) -> list[Book]:
+def goodreads_books(user_id: str, shelf: str) -> list[Book]:
     collected: list[Book] = []
     for page in range(1, MAX_PAGES + 1):
         url = feed_url(user_id, shelf, page)
@@ -162,9 +173,7 @@ def goodreads_books(user_id: str, shelf: str, min_rating: int) -> list[Book]:
         collected.extend(page_books)
         if len(page_books) < 50:  # last page
             break
-    favorites = [b for b in collected if b.rating >= min_rating]
-    favorites.sort(key=lambda b: b.sort_key)
-    return favorites
+    return collected
 
 
 # ---------------------------------------------------------------------------
@@ -189,26 +198,25 @@ def parse_existing(inner: str) -> list[Book]:
     for line in inner.splitlines():
         m = re.match(r"\s*[-*]\s+\*\*(.+?)\*\*\s*,?\s*(?:by\s+(.*))?$", line.strip())
         if m:
-            title = m.group(1).strip()
-            author = (m.group(2) or "").strip().rstrip(".")
-            books.append(Book(title=title, author=author))
+            books.append(Book(title=m.group(1).strip(),
+                              author=(m.group(2) or "").strip().rstrip(".")))
     return books
 
 
-def merge(existing: list[Book], incoming: list[Book], limit: int | None) -> list[Book]:
-    """Existing picks first (order preserved), then new Goodreads books."""
-    seen = {b.key for b in existing}
-    merged = list(existing)
-    added = 0
+def select_top(existing: list[Book], incoming: list[Book], top: int,
+               replace: bool) -> list[Book]:
+    """Merge existing + Goodreads (Goodreads wins on matches), rank, take top N."""
+    pool: dict[str, Book] = {}
+    if not replace:
+        for b in existing:
+            pool[b.key] = b
     for b in incoming:
-        if b.key in seen:
-            continue
-        seen.add(b.key)
-        merged.append(b)
-        added += 1
-        if limit is not None and added >= limit:
-            break
-    return merged
+        prev = pool.get(b.key)
+        if prev is not None and not b.author:
+            b.author = prev.author  # keep a nicer hand-written author if GR lacks one
+        pool[b.key] = b  # Goodreads carries the rating/popularity signal
+    ranked = sorted(pool.values(), key=lambda b: (b.sort_key, b.title.lower()))
+    return ranked[:top] if top > 0 else ranked
 
 
 def render_block(books: list[Book]) -> str:
@@ -224,39 +232,38 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--user-id", default=DEFAULT_USER_ID, help=f"Goodreads numeric user id (default: {DEFAULT_USER_ID})")
     parser.add_argument("--shelf", default=DEFAULT_SHELF, help=f"Shelf to pull (default: {DEFAULT_SHELF})")
-    parser.add_argument("--min-rating", type=int, default=DEFAULT_MIN_RATING, help="Only include books rated at least this (default: 5)")
-    parser.add_argument("--limit", type=int, default=None, help="Cap how many NEW Goodreads books to add (existing are always kept)")
+    parser.add_argument("--top", type=int, default=DEFAULT_TOP, help=f"How many books to keep, by rating then popularity (default: {DEFAULT_TOP}; 0 = all)")
+    parser.add_argument("--min-rating", type=int, default=DEFAULT_MIN_RATING, help="Drop books rated below this before ranking (default: 0 = no floor)")
     parser.add_argument("--from-file", type=Path, help="Read the RSS from a local file instead of fetching (offline mode)")
     parser.add_argument("--about", type=Path, default=ABOUT_MD, help="Path to the About page markdown")
-    parser.add_argument("--replace", action="store_true", help="Replace the list with Goodreads picks instead of merging with existing")
+    parser.add_argument("--replace", action="store_true", help="Ignore the existing list; rank Goodreads books only")
     parser.add_argument("--dry-run", action="store_true", help="Print the result; do not write the file")
     args = parser.parse_args()
 
     about_path: Path = args.about
     text = about_path.read_text()
     before, inner, after = split_markers(text)
-
     existing = parse_existing(inner)
 
     if args.from_file:
         incoming = parse_feed(args.from_file.read_bytes())
-        incoming = [b for b in incoming if b.rating >= args.min_rating]
-        incoming.sort(key=lambda b: b.sort_key)
     else:
-        incoming = goodreads_books(args.user_id, args.shelf, args.min_rating)
+        incoming = goodreads_books(args.user_id, args.shelf)
+
+    if args.min_rating > 0:
+        incoming = [b for b in incoming if b.rating >= args.min_rating]
 
     if not incoming and not existing:
         raise SystemExit("No books found from Goodreads and none existing — nothing to write.")
 
-    base = [] if args.replace else existing
-    merged = merge(base, incoming, args.limit)
+    selected = select_top(existing, incoming, args.top, args.replace)
 
-    block = render_block(merged)
+    block = render_block(selected)
     new_text = before + block + after
 
     print(
-        f"existing: {len(existing)} | from Goodreads (rating>={args.min_rating}): "
-        f"{len(incoming)} | result: {len(merged)}",
+        f"existing: {len(existing)} | from Goodreads: {len(incoming)} "
+        f"| kept top {args.top}: {len(selected)}",
         file=sys.stderr,
     )
 
@@ -266,7 +273,8 @@ def main() -> None:
 
     if new_text != text:
         about_path.write_text(new_text)
-        print(f"Updated {about_path.relative_to(ROOT) if about_path.is_relative_to(ROOT) else about_path}", file=sys.stderr)
+        rel = about_path.relative_to(ROOT) if about_path.is_relative_to(ROOT) else about_path
+        print(f"Updated {rel}", file=sys.stderr)
     else:
         print("No changes.", file=sys.stderr)
 

--- a/scripts/update_books.py
+++ b/scripts/update_books.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Update the Books list on the About page from a Goodreads shelf.
+
+Goodreads retired its public API in 2020, but per-shelf RSS feeds still work:
+
+    https://www.goodreads.com/review/list_rss/<USER_ID>?shelf=<SHELF>
+
+This script pulls a shelf (default: the 5-star "favorites" picks from your
+"read" shelf), merges them with the books already curated on the About page,
+de-duplicates, and rewrites the list in place — between the markers:
+
+    <!-- BOOKS:START ... -->
+    ...
+    <!-- BOOKS:END -->
+
+Books you add by hand between those markers are preserved on every run, so the
+result is always "the ones already in the list, plus picks from Goodreads".
+
+Run it only when you want to refresh the list:
+
+    make books                         # default: 5-star books for the configured user
+    python3 scripts/update_books.py --min-rating 4 --limit 30
+    python3 scripts/update_books.py --from-file feed.xml   # offline / behind an allowlist
+    python3 scripts/update_books.py --dry-run              # preview, write nothing
+
+No third-party dependencies — Python 3 standard library only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+ABOUT_MD = ROOT / "content" / "about" / "_index.md"
+
+DEFAULT_USER_ID = "24370112"  # https://www.goodreads.com/user/show/24370112-daniel-luca
+DEFAULT_SHELF = "read"
+DEFAULT_MIN_RATING = 5  # only pull favorites by default
+MAX_PAGES = 10
+
+START_RE = re.compile(r"<!--\s*BOOKS:START.*?-->", re.IGNORECASE | re.DOTALL)
+END_RE = re.compile(r"<!--\s*BOOKS:END\s*-->", re.IGNORECASE)
+
+USER_AGENT = "Mozilla/5.0 (compatible; cleanunicorn-cv/1.0; +https://cleanunicorn.github.io)"
+
+
+# ---------------------------------------------------------------------------
+# Book model
+# ---------------------------------------------------------------------------
+
+class Book:
+    __slots__ = ("title", "author", "rating", "sort_key")
+
+    def __init__(self, title: str, author: str = "", rating: int = 0, sort_key=()):
+        self.title = title
+        self.author = author
+        self.rating = rating
+        self.sort_key = sort_key
+
+    @property
+    def key(self) -> str:
+        """Normalised title used for de-duplication."""
+        return normalise_title(self.title)
+
+    def to_markdown(self) -> str:
+        if self.author:
+            return f"* **{self.title}** by {self.author}"
+        return f"* **{self.title}**"
+
+
+def normalise_title(title: str) -> str:
+    t = title.lower()
+    t = re.sub(r"\s*\([^)]*\)", "", t)   # drop "(Series, #1)" etc.
+    t = re.sub(r"\s*[:\-–—].*$", "", t)  # drop subtitle after : or dash
+    t = re.sub(r"[^a-z0-9]+", " ", t)    # collapse punctuation
+    return t.strip()
+
+
+def clean_title(title: str) -> str:
+    """Tidy a Goodreads title for display: drop the series parenthetical."""
+    return re.sub(r"\s*\([^)]*\)\s*$", "", title).strip()
+
+
+# ---------------------------------------------------------------------------
+# Goodreads RSS
+# ---------------------------------------------------------------------------
+
+def feed_url(user_id: str, shelf: str, page: int) -> str:
+    return (
+        f"https://www.goodreads.com/review/list_rss/{user_id}"
+        f"?shelf={shelf}&sort=rating&order=d&page={page}"
+    )
+
+
+def fetch(url: str, timeout: int = 30) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read()
+
+
+def parse_feed(xml_bytes: bytes) -> list[Book]:
+    """Parse a Goodreads list_rss payload into Book objects."""
+    root = ET.fromstring(xml_bytes)
+    books: list[Book] = []
+    for item in root.iter("item"):
+        title = (item.findtext("title") or "").strip()
+        if not title:
+            continue
+        author = (item.findtext("author_name") or "").strip()
+        try:
+            rating = int((item.findtext("user_rating") or "0").strip())
+        except ValueError:
+            rating = 0
+        when = parse_date(item.findtext("user_read_at") or item.findtext("user_date_added") or "")
+        books.append(
+            Book(
+                title=clean_title(title),
+                author=author,
+                rating=rating,
+                # higher rating first, then most recently read/added
+                sort_key=(-rating, -when),
+            )
+        )
+    return books
+
+
+def parse_date(value: str) -> float:
+    """RFC-822 date string -> POSIX timestamp (0.0 if unparseable)."""
+    value = value.strip()
+    if not value:
+        return 0.0
+    try:
+        return parsedate_to_datetime(value).timestamp()
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def goodreads_books(user_id: str, shelf: str, min_rating: int) -> list[Book]:
+    collected: list[Book] = []
+    for page in range(1, MAX_PAGES + 1):
+        url = feed_url(user_id, shelf, page)
+        try:
+            payload = fetch(url)
+        except urllib.error.HTTPError as exc:
+            raise SystemExit(
+                f"Goodreads returned HTTP {exc.code} for {url}\n"
+                "The shelf must be public. If you are behind a network allowlist, "
+                "save the feed locally and pass --from-file."
+            )
+        except urllib.error.URLError as exc:
+            raise SystemExit(f"Could not reach Goodreads: {exc.reason}")
+        page_books = parse_feed(payload)
+        if not page_books:
+            break
+        collected.extend(page_books)
+        if len(page_books) < 50:  # last page
+            break
+    favorites = [b for b in collected if b.rating >= min_rating]
+    favorites.sort(key=lambda b: b.sort_key)
+    return favorites
+
+
+# ---------------------------------------------------------------------------
+# About page I/O
+# ---------------------------------------------------------------------------
+
+def split_markers(text: str) -> tuple[str, str, str]:
+    """Return (before, inner, after) around the BOOKS markers."""
+    s = START_RE.search(text)
+    e = END_RE.search(text, s.end()) if s else None
+    if not s or not e:
+        raise SystemExit(
+            "Could not find the <!-- BOOKS:START --> / <!-- BOOKS:END --> markers "
+            f"in {ABOUT_MD.relative_to(ROOT)}. Add them around the Books list first."
+        )
+    return text[: s.end()], text[s.end() : e.start()], text[e.start() :]
+
+
+def parse_existing(inner: str) -> list[Book]:
+    """Read the books already listed between the markers."""
+    books: list[Book] = []
+    for line in inner.splitlines():
+        m = re.match(r"\s*[-*]\s+\*\*(.+?)\*\*\s*,?\s*(?:by\s+(.*))?$", line.strip())
+        if m:
+            title = m.group(1).strip()
+            author = (m.group(2) or "").strip().rstrip(".")
+            books.append(Book(title=title, author=author))
+    return books
+
+
+def merge(existing: list[Book], incoming: list[Book], limit: int | None) -> list[Book]:
+    """Existing picks first (order preserved), then new Goodreads books."""
+    seen = {b.key for b in existing}
+    merged = list(existing)
+    added = 0
+    for b in incoming:
+        if b.key in seen:
+            continue
+        seen.add(b.key)
+        merged.append(b)
+        added += 1
+        if limit is not None and added >= limit:
+            break
+    return merged
+
+
+def render_block(books: list[Book]) -> str:
+    lines = "\n".join(b.to_markdown() for b in books)
+    return f"\n\n{lines}\n\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--user-id", default=DEFAULT_USER_ID, help=f"Goodreads numeric user id (default: {DEFAULT_USER_ID})")
+    parser.add_argument("--shelf", default=DEFAULT_SHELF, help=f"Shelf to pull (default: {DEFAULT_SHELF})")
+    parser.add_argument("--min-rating", type=int, default=DEFAULT_MIN_RATING, help="Only include books rated at least this (default: 5)")
+    parser.add_argument("--limit", type=int, default=None, help="Cap how many NEW Goodreads books to add (existing are always kept)")
+    parser.add_argument("--from-file", type=Path, help="Read the RSS from a local file instead of fetching (offline mode)")
+    parser.add_argument("--about", type=Path, default=ABOUT_MD, help="Path to the About page markdown")
+    parser.add_argument("--replace", action="store_true", help="Replace the list with Goodreads picks instead of merging with existing")
+    parser.add_argument("--dry-run", action="store_true", help="Print the result; do not write the file")
+    args = parser.parse_args()
+
+    about_path: Path = args.about
+    text = about_path.read_text()
+    before, inner, after = split_markers(text)
+
+    existing = parse_existing(inner)
+
+    if args.from_file:
+        incoming = parse_feed(args.from_file.read_bytes())
+        incoming = [b for b in incoming if b.rating >= args.min_rating]
+        incoming.sort(key=lambda b: b.sort_key)
+    else:
+        incoming = goodreads_books(args.user_id, args.shelf, args.min_rating)
+
+    if not incoming and not existing:
+        raise SystemExit("No books found from Goodreads and none existing — nothing to write.")
+
+    base = [] if args.replace else existing
+    merged = merge(base, incoming, args.limit)
+
+    block = render_block(merged)
+    new_text = before + block + after
+
+    print(
+        f"existing: {len(existing)} | from Goodreads (rating>={args.min_rating}): "
+        f"{len(incoming)} | result: {len(merged)}",
+        file=sys.stderr,
+    )
+
+    if args.dry_run:
+        sys.stdout.write(block)
+        return
+
+    if new_text != text:
+        about_path.write_text(new_text)
+        print(f"Updated {about_path.relative_to(ROOT) if about_path.is_relative_to(ROOT) else about_path}", file=sys.stderr)
+    else:
+        print("No changes.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/static/css/cv.css
+++ b/static/css/cv.css
@@ -1,20 +1,18 @@
-/* CV — hacker edition */
+/* CV — matches the website's palette and type (warm background, single
+   emerald accent, Fira Code) so the resume reads as the same brand.
+   Screen styles are dark; @media print switches to a clean light sheet. */
 
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Space+Grotesk:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;500;600;700&display=swap');
 
 :root {
-  --bg:      #0a0a0f;
-  --surface: #12121a;
-  --border:  #1e1e2e;
-  --text:    #c9ccd3;
-  --bright:  #e4e6eb;
-  --muted:   #5a5e6b;
-  --green:   #00ff9d;
-  --cyan:    #00d4ff;
-  --magenta: #ff00aa;
-  --amber:   #ffb800;
-  --dim-green: rgba(0, 255, 157, 0.08);
-  --glow-green: 0 0 20px rgba(0, 255, 157, 0.15);
+  --bg:      #1a170f;
+  --surface: #221d12;
+  --border:  rgba(236, 234, 229, 0.14);
+  --text:    #d7d4cc;
+  --bright:  #eceae5;
+  --muted:   rgba(236, 234, 229, 0.55);
+  --accent:  #3fd68a;
+  --accent-dim: rgba(63, 214, 138, 0.10);
 }
 
 *, *::before, *::after {
@@ -24,78 +22,60 @@
 }
 
 body {
-  font-family: "Space Grotesk", "Inter", system-ui, sans-serif;
+  font-family: "Fira Code", Monaco, Consolas, "Ubuntu Mono", monospace;
   font-size: 10.5pt;
-  line-height: 1.5;
+  line-height: 1.55;
   color: var(--text);
   background: var(--bg);
   max-width: 820px;
   margin: 0 auto;
-  padding: 40px 48px;
+  padding: 44px 48px;
   -webkit-font-smoothing: antialiased;
-}
-
-/* Subtle scanline overlay */
-body::before {
-  content: "";
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: repeating-linear-gradient(
-    transparent,
-    transparent 2px,
-    rgba(0, 0, 0, 0.03) 2px,
-    rgba(0, 0, 0, 0.03) 4px
-  );
-  pointer-events: none;
-  z-index: 999;
 }
 
 /* ── Header ── */
 header {
-  text-align: center;
-  margin-bottom: 32px;
-  padding-bottom: 20px;
-  border-bottom: 1px solid var(--border);
-  position: relative;
-}
-
-header::after {
-  content: "";
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  width: 100%;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--green), transparent);
-  opacity: 0.5;
+  margin-bottom: 30px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--accent);
 }
 
 header h1 {
-  font-family: "JetBrains Mono", "Fira Code", monospace;
-  font-size: 28pt;
-  font-weight: 700;
+  font-size: 26pt;
+  font-weight: 600;
   color: var(--bright);
   letter-spacing: -0.02em;
-  margin-bottom: 6px;
-  text-shadow: 0 0 30px rgba(0, 255, 157, 0.12);
+  margin-bottom: 8px;
 }
 
 header h1::before {
-  content: "> ";
-  color: var(--green);
+  content: "~$ ";
+  color: var(--accent);
   font-weight: 400;
 }
 
 header .subtitle {
-  font-family: "JetBrains Mono", monospace;
   font-size: 10pt;
-  color: var(--muted);
+  color: var(--accent);
   font-weight: 400;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+header .contact {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 18px;
+  font-size: 9pt;
+}
+
+header .contact a {
+  color: var(--muted);
+}
+
+header .contact a:hover {
+  color: var(--accent);
 }
 
 /* ── Sections ── */
@@ -104,33 +84,75 @@ section {
 }
 
 section > h2 {
-  font-family: "JetBrains Mono", monospace;
-  font-size: 10.5pt;
+  font-size: 10pt;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--green);
-  padding: 6px 12px;
-  margin-bottom: 12px;
-  background: var(--dim-green);
-  border-left: 3px solid var(--green);
-  border-radius: 0 4px 4px 0;
+  letter-spacing: 0.14em;
+  color: var(--accent);
+  padding: 5px 12px;
+  margin-bottom: 14px;
+  background: var(--accent-dim);
+  border-left: 3px solid var(--accent);
+}
+
+/* ── Summary ── */
+.bio {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 16px 20px;
+  margin-bottom: 26px;
+}
+
+.bio p { margin-bottom: 8px; }
+.bio p:last-child { margin-bottom: 0; }
+
+/* ── Work entries ── */
+.work h2 ~ h2 {
+  font-size: 12pt;
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: normal;
+  color: var(--bright);
+  background: none;
+  border-left: 2px solid var(--accent);
+  padding: 0 0 0 12px;
+  margin-top: 18px;
+  margin-bottom: 2px;
+}
+
+/* The date line (a wholly-italic paragraph right under a role heading). */
+.work h2 + p > em {
+  display: inline-block;
+  font-style: normal;
+  font-size: 0.82em;
+  letter-spacing: 0.03em;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+
+.work p, .work ul {
+  margin-bottom: 4px;
+  padding-left: 14px;
+}
+
+.work > p, .work > ul {
+  border-left: 1px solid var(--border);
+  margin-left: 1px;
 }
 
 /* ── Skills ── */
 .skills .skill-group {
   display: grid;
-  grid-template-columns: 140px 1fr;
+  grid-template-columns: 150px 1fr;
   gap: 8px;
   align-items: baseline;
   margin-bottom: 8px;
 }
 
 .skills .skill-category {
-  font-family: "JetBrains Mono", monospace;
   font-size: 8.5pt;
   font-weight: 600;
-  color: var(--cyan);
+  color: var(--accent);
   text-transform: uppercase;
   letter-spacing: 0.06em;
   padding-top: 3px;
@@ -144,123 +166,18 @@ section > h2 {
 
 .skills .skill-tag {
   display: inline-block;
-  font-family: "JetBrains Mono", monospace;
   font-size: 8.5pt;
   padding: 2px 10px;
   border: 1px solid var(--border);
-  border-radius: 3px;
   color: var(--bright);
   background: var(--surface);
-  transition: all 0.15s ease;
 }
 
-.skills .skill-tag:hover {
-  border-color: var(--green);
-  color: var(--green);
-  box-shadow: var(--glow-green);
-}
-
-/* ── Work entries ── */
-.work h2 ~ h2 {
-  font-family: "Space Grotesk", sans-serif;
-  font-size: 11pt;
-  font-weight: 600;
-  text-transform: none;
-  letter-spacing: normal;
-  color: var(--bright);
-  background: none;
-  border-left: 2px solid var(--border);
-  border-radius: 0;
-  padding: 0 0 0 10px;
-  margin-top: 16px;
-  margin-bottom: 4px;
-}
-
-.work p, .work ul {
-  margin-bottom: 4px;
-  padding-left: 15px;
-}
-
-.work > ul,
-.work > p {
-  border-left: 1px solid var(--border);
-  margin-left: 1px;
-}
-
-/* Metadata bullets (Company, Since, Until) */
-.work li strong {
-  color: var(--cyan);
-  font-family: "JetBrains Mono", monospace;
-  font-size: 0.9em;
-  font-weight: 500;
-}
-
-/* ── Links / Contact ── */
-.links ul {
-  list-style: none;
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
-.links li {
-  white-space: nowrap;
-}
-
-.links li a {
-  display: inline-block;
-  padding: 4px 14px;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  font-family: "JetBrains Mono", monospace;
-  font-size: 9.5pt;
-  color: var(--cyan);
-  transition: all 0.2s ease;
-}
-
-.links li a:hover {
-  border-color: var(--cyan);
-  background: rgba(0, 212, 255, 0.06);
-  box-shadow: 0 0 12px rgba(0, 212, 255, 0.1);
-  text-decoration: none;
-}
-
-/* ── Lists ── */
-ul {
-  padding-left: 18px;
-  margin-bottom: 6px;
-}
-
-li {
-  margin-bottom: 3px;
-}
-
-li::marker {
-  color: var(--muted);
-}
-
-/* ── Bio ── */
-.bio {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 16px 20px;
-  margin-bottom: 24px;
-}
-
-.bio p {
-  margin-bottom: 8px;
-}
-
-.bio p:last-child {
-  margin-bottom: 0;
-}
-
-/* ── Talks ── */
+/* ── Talks / Podcasts ── */
 .talks li,
 .podcasts li {
-  font-size: 10pt;
+  font-size: 9.5pt;
+  margin-bottom: 3px;
 }
 
 .talks li a,
@@ -270,13 +187,7 @@ li::marker {
 
 .talks li a:hover,
 .podcasts li a:hover {
-  color: var(--cyan);
-}
-
-/* Year prefix highlight */
-.talks li a::first-line,
-.podcasts li a::first-line {
-  color: var(--amber);
+  color: var(--accent);
 }
 
 /* ── Projects ── */
@@ -291,153 +202,73 @@ li::marker {
 .projects li {
   padding: 8px 12px;
   border: 1px solid var(--border);
-  border-radius: 4px;
   background: var(--surface);
-  transition: border-color 0.2s ease;
 }
 
-.projects li:hover {
-  border-color: var(--green);
-}
+.projects li a { color: var(--accent); }
 
-.projects li a {
-  color: var(--green);
-}
+/* ── Lists / typography ── */
+ul { padding-left: 18px; margin-bottom: 6px; }
+li { margin-bottom: 3px; }
+li::marker { color: var(--accent); }
 
-.projects li strong {
-  font-family: "JetBrains Mono", monospace;
-  font-size: 0.95em;
-}
-
-/* ── Typography ── */
 a {
-  color: var(--cyan);
+  color: var(--accent);
   text-decoration: none;
   transition: color 0.15s ease;
 }
+a:hover { color: var(--bright); }
 
-a:hover {
-  color: var(--green);
-  text-decoration: none;
-}
-
-strong {
-  font-weight: 600;
-  color: var(--bright);
-}
-
-p {
-  margin-bottom: 4px;
-}
+strong { font-weight: 600; color: var(--bright); }
+p { margin-bottom: 4px; }
 
 code {
-  font-family: "JetBrains Mono", monospace;
   font-size: 0.9em;
   background: var(--surface);
-  color: var(--amber);
-  padding: 2px 6px;
-  border-radius: 3px;
+  color: var(--accent);
+  padding: 1px 6px;
   border: 1px solid var(--border);
 }
 
 /* ── Footer ── */
 footer {
-  margin-top: 32px;
+  margin-top: 30px;
   padding-top: 12px;
   border-top: 1px solid var(--border);
   text-align: center;
-  font-family: "JetBrains Mono", monospace;
   font-size: 7.5pt;
   color: var(--muted);
-  position: relative;
 }
+footer a { color: var(--muted); }
 
-footer::before {
-  content: "";
-  position: absolute;
-  top: -1px;
-  left: 0;
-  width: 100%;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--green), transparent);
-  opacity: 0.3;
-}
-
-footer a {
-  color: var(--muted);
-}
-
-/* ── Print ── */
+/* ── Print: clean light sheet, same emerald accent darkened for contrast ── */
 @media print {
   :root {
-    --bg:      #fff;
-    --surface: #f8f8fa;
-    --border:  #d0d0d0;
-    --text:    #1a1a1a;
-    --bright:  #000;
-    --muted:   #666;
-    --green:   #007a4d;
-    --cyan:    #0066aa;
-    --magenta: #990066;
-    --amber:   #996600;
-    --dim-green: rgba(0, 122, 77, 0.06);
+    --bg:      #ffffff;
+    --surface: #f6f7f5;
+    --border:  #d9d9d4;
+    --text:    #1c1c1a;
+    --bright:  #000000;
+    --muted:   #5d5d57;
+    --accent:  #157a4d;
+    --accent-dim: rgba(21, 122, 77, 0.07);
   }
 
-  body {
-    padding: 0;
-    font-size: 10pt;
-    max-width: 100%;
-  }
+  body { padding: 0; font-size: 10pt; max-width: 100%; }
+  header { margin-bottom: 16px; }
+  section { margin-bottom: 14px; }
 
-  body::before {
-    display: none;
-  }
+  .bio { background: var(--surface); border-color: var(--border); }
+  .projects li { background: transparent; }
+  .skills .skill-tag { background: transparent; }
+  a { color: var(--text); }
+  .work h2 + p > em { color: var(--muted); }
 
-  header {
-    margin-bottom: 16px;
-  }
-
-  header h1 {
-    text-shadow: none;
-  }
-
-  section {
-    margin-bottom: 14px;
-  }
-
-  .bio {
-    background: var(--surface);
-    border-color: var(--border);
-  }
-
-  .projects li {
-    background: transparent;
-    border-color: var(--border);
-    padding: 4px 8px;
-  }
-
-  .skills .skill-tag {
-    background: transparent;
-    border-color: var(--border);
-  }
-
-  .links li a {
-    border-color: var(--border);
-    color: var(--text);
-  }
-
-  a {
-    color: var(--text);
-  }
-
-  .work h2,
-  .work h2 + ul,
+  .work h2 ~ h2,
   .work h2 + p,
-  li {
-    page-break-inside: avoid;
-  }
+  li,
+  .projects li,
+  .skills .skill-group { page-break-inside: avoid; }
 
-  footer {
-    display: none;
-  }
+  footer { display: none; }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -37,6 +37,15 @@ h3 { font-size: calc(var(--font-size) * 1.12); }
 
 p { line-height: 1.7; }
 
+/* Long, short-item lists (About: Talks, Books) flow into balanced columns
+   on wide viewports and collapse to one column on narrow ones. */
+.cols ul {
+  column-width: 21rem;
+  column-gap: 2.5rem;
+  margin-top: 0.5rem;
+}
+.cols li { break-inside: avoid; }
+
 /* CV/Work date lines: a wholly-italic paragraph sitting directly under a
    section heading is metadata, not prose — render it as a quiet meta line. */
 .content h2 + p > em:only-child {

--- a/static/style.css
+++ b/static/style.css
@@ -37,6 +37,17 @@ h3 { font-size: calc(var(--font-size) * 1.12); }
 
 p { line-height: 1.7; }
 
+/* CV/Work date lines: a wholly-italic paragraph sitting directly under a
+   section heading is metadata, not prose — render it as a quiet meta line. */
+.content h2 + p > em:only-child {
+  display: inline-block;
+  margin-top: -0.6rem;
+  font-style: normal;
+  font-size: calc(var(--font-size) * 0.82);
+  letter-spacing: 0.03em;
+  color: var(--muted);
+}
+
 /* Constrain prose measure on text pages for readability */
 .post-content p,
 .index-content p,

--- a/static/terminal.css
+++ b/static/terminal.css
@@ -1,5 +1,5 @@
-/* Fira Code: https://github.com/tonsky/FiraCode */
-@import url('https://cdn.staticdelivr.com/gfonts/css2?family=Fira+Code:wght@300..700&display=swap');
+/* Fira Code is self-hosted by the theme via @font-face (themes/terminal/assets/css/fonts.css);
+   no webfont @import is needed here. */
 
 :root {
   --background: #1a170f;

--- a/static/terminal.css
+++ b/static/terminal.css
@@ -4,7 +4,7 @@
 :root {
   --background: #1a170f;
   --foreground: #eceae5;
-  --accent: #5dee60;
+  --accent: #3fd68a;
   --radius: 0;
   --font-size: 1rem;
   --line-height: 1.54em;

--- a/static/terminal.css
+++ b/static/terminal.css
@@ -1,27 +1,23 @@
-/* Fira Code is self-hosted by the theme via @font-face (themes/terminal/assets/css/fonts.css);
-   no webfont @import is needed here. */
+/* Palette and a few deliberate overrides layered on top of the terminal
+   theme's own main.css (loaded first via the asset pipeline). Only the
+   genuine deltas live here — everything else is inherited from the theme.
+   Fira Code is self-hosted by the theme (themes/terminal/assets/css/fonts.css),
+   so no webfont @import is needed. */
 
 :root {
-  --background: #1a170f;
-  --foreground: #eceae5;
   --accent: #3fd68a;
-  --radius: 0;
-  --font-size: 1rem;
-  --line-height: 1.54em;
 }
 
-html {
-  box-sizing: border-box;
-}
-
+/* Reset default margins/padding (the theme only normalises box-sizing). */
 *,
-*:before,
-*:after {
+*::before,
+*::after {
   box-sizing: inherit;
   margin: 0;
   padding: 0;
 }
 
+/* Enable Fira Code's contextual ligatures and add a modern mono fallback. */
 body {
   font-family:
     "Fira Code",
@@ -30,364 +26,33 @@ body {
     Consolas,
     "Ubuntu Mono",
     monospace;
-  font-size: var(--font-size);
   font-weight: 400;
-  line-height: var(--line-height);
-  background-color: var(--background);
-  color: var(--foreground);
-  text-rendering: optimizeLegibility;
   font-variant-ligatures: contextual;
-  -webkit-overflow-scrolling: touch;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
 }
 
-h1 {
-  font-size: calc(var(--font-size) * 1.45);
-  letter-spacing: 0;
-}
-
-h2 {
-  font-size: calc(var(--font-size) * 1.35);
-  letter-spacing: 0;
-}
-
-h3 {
-  font-size: calc(var(--font-size) * 1.15);
-  letter-spacing: 0;
-}
-
-h4,
-h5,
-h6 {
-  font-size: calc(var(--font-size) * 1);
-  letter-spacing: 0;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-ul,
-ol,
-img,
-figure,
-video,
-table {
-  margin: 25px 0;
-}
-
-a {
-  color: var(--accent);
-}
-
-button {
-  position: relative;
-  font: inherit;
-  font-weight: bold;
-  text-decoration: none;
-  text-align: center;
-  background: transparent;
-  color: var(--accent);
-  padding: 5px 18px;
-  border: 4px solid var(--accent);
-  border-radius: var(--radius);
-  transition: background 0.15s linear;
-  appearance: none;
-  cursor: pointer;
-  outline: none;
-}
-
-button:hover {
-  background: color-mix(in srgb, var(--accent) 15%, transparent);
-}
-
-button:focus-visible,
-a:focus-visible {
-  outline: 1px solid var(--accent);
-  outline-offset: 2px;
-}
-
-fieldset {
-  display: inline-block;
-  border: 2px solid var(--foreground);
-  border-radius: calc(var(--radius) * 1.6);
-  padding: 10px;
-}
-
-fieldset *:first-child {
-  margin-top: 0;
-}
-
-fieldset input,
-fieldset select,
-fieldset textarea,
-fieldset label,
-fieldset button {
-  margin-top: calc(var(--line-height) * 0.5);
-  width: 100%;
-}
-
-label {
-  display: inline-block;
-}
-
-label input {
-  margin-top: 0;
-}
-
-input,
-textarea,
-select {
-  background: transparent;
-  color: var(--foreground);
-  border: 1px solid var(--foreground);
-  border-radius: var(--radius);
-  padding: 10px;
-  font: inherit;
-  appearance: none;
-}
-
-input[type="checkbox"] {
-  width: auto;
-}
-
-input:focus-visible,
-input:active,
-textarea:focus-visible,
-textarea:active,
-select:focus-visible,
-select:active {
-  border-color: var(--accent);
-  outline: 1px solid var(--accent);
-  outline-offset: 2px;
-}
-
-input:active,
-textarea:active,
-select:active {
-  box-shadow: none;
-}
-
-select {
-  background-image: linear-gradient(45deg,
-      transparent 50%,
-      var(--foreground) 50%),
-    linear-gradient(135deg, var(--foreground) 50%, transparent 50%);
-  background-position: calc(100% - 20px), calc(100% - 15px);
-  background-size:
-    5px 5px,
-    5px 5px;
-  background-repeat: no-repeat;
-  padding-right: 40px;
-}
-
-select option {
-  background: var(--background);
-}
-
-input[type="checkbox"],
-input[type="radio"] {
-  vertical-align: middle;
-  padding: 10px;
-  box-shadow: inset 0 0 0 3px var(--background);
-}
-
-input[type="radio"] {
-  display: inline-block;
-  width: 10px !important;
-  height: 10px !important;
-  border-radius: 20px;
-}
-
-input[type="checkbox"]:checked,
-input[type="radio"]:checked {
-  background: var(--accent);
-}
-
-img {
-  display: block;
-  max-width: 100%;
-  border: 8px solid var(--accent);
-  border-radius: var(--radius);
-  padding: 8px;
-  overflow: hidden;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-figure img,
-figure video {
-  margin-bottom: 0;
-}
-
-figure figcaption {
-  background: var(--accent);
-  color: var(--background);
-  text-align: center;
-  font-size: 1em;
-  font-weight: normal;
-  margin-top: -8px;
-  border-radius: 0 0 var(--radius) var(--radius);
-}
-
-ul,
-ol {
-  margin-left: 4ch;
-  padding: 0;
-}
-
-ul ul,
-ul ol,
-ol ul,
-ol ol {
-  margin-top: 0;
-}
-
-li::marker {
-  color: var(--accent);
-}
-
-ul li,
-ol li {
-  position: relative;
-}
-
+/* Tint inline code and code blocks toward the accent, with a hairline border. */
 code,
 kbd {
-  font-family:
-    "Fira Code",
-    "JetBrains Mono",
-    Monaco,
-    Consolas,
-    Ubuntu Mono,
-    monospace !important;
-  font-feature-settings: normal;
-  background: color-mix(in srgb, var(--foreground) 5%, transparent);
   color: color-mix(in srgb, var(--foreground) 5%, var(--accent));
-  padding: 0 6px;
-  margin: 0 2px;
-  font-size: 0.95em;
 }
 
 code {
   border: 1px solid color-mix(in srgb, var(--foreground) 25%, transparent);
-}
-
-kbd {
-  border-top: 1px solid color-mix(in srgb, var(--accent) 25%, transparent);
-  border-left: 1px solid var(--accent);
-  border-right: 1px solid var(--accent);
-  border-bottom: 4px solid var(--accent);
-  border-radius: 4px;
-}
-
-code code {
-  background: transparent;
-  padding: 0;
-  margin: 0;
+  padding: 0 6px;
 }
 
 pre {
-  tab-size: 4;
-  background: color-mix(in srgb, var(--foreground) 5%, transparent) !important;
   color: color-mix(in srgb, var(--foreground) 5%, var(--accent));
-  padding: 20px 10px;
-  font-size: 0.95em !important;
-  overflow: auto;
-  border-radius: var(--radius);
   border: 1px solid color-mix(in srgb, var(--foreground) 25%, transparent);
 }
 
-pre code {
-  background: none !important;
-  margin: 0;
-  padding: 0;
-  font-size: inherit;
-  border: none;
+/* Center standalone images. */
+img {
+  margin-left: auto;
+  margin-right: auto;
 }
 
-sup {
-  line-height: 0;
-}
-
-abbr {
-  position: relative;
-  text-decoration-style: wavy;
-  text-decoration-color: var(--accent);
-  cursor: help;
-}
-
-sub {
-  bottom: -0.25em;
-}
-
-sup {
-  top: -0.25em;
-}
-
-mark {
-  background: color-mix(in srgb, var(--accent) 45%, transparent);
-  color: var(--foreground);
-}
-
-blockquote {
-  position: relative;
-  border-top: 1px solid var(--accent);
-  border-bottom: 1px solid var(--accent);
-  margin: 0;
-  padding: 25px;
-}
-
-blockquote:before {
-  content: ">";
-  display: block;
-  position: absolute;
-  left: 0;
-  color: var(--accent);
-}
-
-blockquote p:first-child {
-  margin-top: 0;
-}
-
-blockquote p:last-child {
-  margin-bottom: 0;
-}
-
-table {
-  table-layout: auto;
-  border-collapse: collapse;
-}
-
-table,
-th,
-td {
-  border: 2px solid var(--foreground);
-  padding: 10px;
-}
-
-th {
-  border-style: solid;
-  color: var(--foreground);
-  text-align: left;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-hr {
-  width: 100%;
-  border: none;
-  background: var(--accent);
-  height: 2px;
-}
-
-/* Bold elements */
-
+/* Headings and bold text sit at 600 rather than the user-agent 700. */
 h1,
 h2,
 h3,


### PR DESCRIPTION
- Recolor accent from neon matrix-green (#5dee60) to a calmer emerald
  (#3fd68a) that keeps the terminal/security identity but harmonizes with
  the warm background and reads more senior.
- Give the hero headline more presence (1.6 -> 1.9x) with tighter
  line-height and an open tier of space below the eyebrow, so the value
  proposition lands first.
- Add a sharp one-line description to every post. This replaces the
  bloated auto-summaries (which leaked headings and cover images) on the
  posts index and home "Latest writing" with clean, scannable copy, and
  improves SEO/OG previews.
- Fix mis-cased post titles: "Making Ais" -> "Making AIs" and
  "(Eip 1153)" -> "(EIP 1153)".