### PR TITLE
feat(home): make the hero full-bleed

### DIFF
--- a/assets/css/z-base.css
+++ b/assets/css/z-base.css
@@ -87,6 +87,11 @@
 
 /* ---- Body & rhythm -------------------------------------------------------- */
 body {
+  /* The home hero breaks out to 100vw (margin: 0 calc(50% - 50vw)). Clip any
+     sub-pixel/scrollbar overshoot here so a full-bleed child never spawns a
+     horizontal scrollbar. `clip` (not `hidden`) keeps normal vertical scroll
+     and doesn't create a scroll container. */
+  overflow-x: clip;
   font-family: var(--font-mono);
   font-weight: 400;
   font-variant-ligatures: contextual;

--- a/assets/css/z-connect.css
+++ b/assets/css/z-connect.css
@@ -17,7 +17,11 @@
    POSTER HERO
    ======================================================================== */
 .poster {
-  margin: var(--sp-5) 0 var(--sp-6);
+  /* Full-bleed: the hero breaks out of the centred 53rem column to span the
+     whole viewport, while the page chrome (header, board, writing) stays in the
+     column. The negative inline margins widen this flex item to the viewport;
+     the scrollbar-safe clamp lives on <body> (overflow-x: clip, z-base.css). */
+  margin: 0 calc(50% - 50vw) var(--sp-7);
   animation: fade-up var(--dur-slow) var(--ease) both;
 }
 
@@ -25,18 +29,31 @@
   position: relative;
   isolation: isolate;
   overflow: hidden;
-  border: 1px solid var(--accent-line);
-  border-radius: var(--radius);
-  /* A tight inner ring + a soft, contained drop shadow — no wide emerald bleed
-     that would make the hero feel like it escapes the column. */
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--accent) 16%, transparent),
-    0 16px 38px -34px color-mix(in srgb, var(--accent) 28%, transparent);
+  display: flex;                /* hosts the column-pinned .poster__inner */
   background: var(--background);
-  /* portrait fills the frame; aspect ratio keeps it poster-like on all widths */
-  aspect-ratio: 4 / 5;
-  max-height: 72vh;
-  min-height: 420px;
+  /* Width is the full viewport now, so height is driven by the viewport (not an
+     aspect ratio, which would balloon on ultra-wide monitors). */
+  height: clamp(440px, 60vh, 620px);
+  /* A single emerald hairline grounds the bleed against the board below; no
+     side border (it would sit flush against the screen edge). */
+  border-bottom: 1px solid var(--accent-line);
+}
+
+/* The content column inside the full-bleed frame: same max-width + side padding
+   as .container.center, centred, so the eyebrow and name line up exactly with
+   the header logo and the board beneath. Eyebrow pins to the top, identity block
+   to the bottom. */
+.poster__inner {
+  position: relative;
+  z-index: 3;
+  width: 100%;
+  max-width: 53rem;
+  margin-inline: auto;
+  padding: var(--sp-5) var(--sp-6);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: var(--sp-5);
 }
 
 .poster__photo {
@@ -82,15 +99,11 @@
     transparent 72%);
 }
 
-/* Terminal eyebrow, top-left over the image */
+/* Terminal eyebrow chip, pinned to the top of the column */
 .poster__eyebrow {
-  position: absolute;
-  z-index: 3;
-  top: var(--sp-4);
-  left: var(--sp-5);
-  right: auto;
-  max-width: calc(100% - 2 * var(--sp-5));
+  align-self: flex-start;
   width: fit-content;
+  max-width: 100%;
   margin: 0;
   display: flex;
   flex-wrap: wrap;
@@ -101,7 +114,7 @@
   color: var(--accent-bright);
   /* A localized translucent backing (a small terminal chip) keeps the eyebrow
      AA-legible over any region of the photo without darkening a band across the
-     top of the image — which previously read as a gap before the portrait. */
+     top of the image. */
   background: color-mix(in srgb, var(--background) 52%, transparent);
   backdrop-filter: blur(3px);
   border-radius: var(--radius);
@@ -119,13 +132,9 @@
   animation: blink 1.1s steps(1) infinite;
 }
 
-/* Name + tagline block, bottom-anchored over the scrim */
+/* Name + tagline block, sitting at the bottom of the column over the scrim */
 .poster__id {
-  position: absolute;
-  z-index: 3;
-  left: var(--sp-5);
-  right: var(--sp-5);
-  bottom: var(--sp-5);
+  max-width: 40rem;
 }
 
 .poster__name {
@@ -327,30 +336,25 @@
    Responsive
    ======================================================================== */
 
-/* ---- Desktop (≥768px): cinematic, wider poster + roomy board ------------- */
+/* ---- Desktop (≥768px): cinematic full-bleed band + roomy board ----------- */
 @media (min-width: 768px) {
   .poster__frame {
-    /* A balanced hero rectangle — not a wide letterbox that reads as "too wide". */
-    aspect-ratio: 3 / 2;
-    min-height: 440px;
-    max-height: 600px;
+    height: clamp(460px, 62vh, 640px);
   }
   .poster__photo { object-position: 50% 30%; }
-  /* On wide screens, fade the scrim from the left so text sits on a darker side */
+  /* Bias the scrim toward the bottom-left where the name sits, so it stays AA
+     over the portrait without dimming the whole image. */
   .poster__scrim {
-    background: linear-gradient(
-      105deg,
-      color-mix(in srgb, var(--background) 92%, transparent) 0%,
-      color-mix(in srgb, var(--background) 78%, transparent) 30%,
-      color-mix(in srgb, var(--background) 30%, transparent) 58%,
-      transparent 78%);
-  }
-  .poster__id {
-    bottom: auto;
-    top: 50%;
-    transform: translateY(-50%);
-    right: auto;
-    max-width: 58%;
+    background:
+      linear-gradient(
+        to top,
+        color-mix(in srgb, var(--background) 92%, transparent) 0%,
+        color-mix(in srgb, var(--background) 60%, transparent) 26%,
+        transparent 62%),
+      linear-gradient(
+        100deg,
+        color-mix(in srgb, var(--background) 70%, transparent) 0%,
+        transparent 52%);
   }
   .poster__tagline { font-size: 1.08rem; }
 
@@ -360,14 +364,13 @@
 
 /* ---- Mobile (≤640px): collapse board columns — handle drops beneath the
    channel name, action stays reachable on the right; rows keep ≥44px tap
-   height. The poster goes full-width 3:4 with the name legible over the scrim. */
+   height. The full-bleed poster shortens and the name stays legible over the
+   scrim. */
 @media (max-width: 640px) {
   .poster__frame {
-    aspect-ratio: 3 / 4;
-    min-height: 0;
+    height: clamp(440px, 76vh, 560px);
   }
-  .poster__eyebrow { top: var(--sp-3); left: var(--sp-4); right: auto; max-width: calc(100% - 2 * var(--sp-4)); }
-  .poster__id { left: var(--sp-4); right: var(--sp-4); bottom: var(--sp-4); }
+  .poster__inner { padding-block: var(--sp-4); }
   .poster__name { font-size: clamp(2.4rem, 9vw, 3.4rem); }
   .poster__tagline { font-size: 0.95rem; }
 
@@ -393,15 +396,17 @@
   .board__row--featured { padding-block: var(--sp-4); min-height: 56px; }
 }
 
+/* ---- ≤560px: mirror .container.center's tighter side padding so the hero
+   text keeps aligning with the page chrome. */
+@media (max-width: 560px) {
+  .poster__inner { padding-inline: var(--sp-5); }
+}
+
 /* ---- Short viewports: cap the poster so at least the booking row is
    reachable without the portrait burying the panel. */
 @media (max-width: 640px) and (max-height: 760px) {
   .poster__frame {
-    aspect-ratio: auto;
     height: 56vh;
-    /* Let 56vh actually govern on short/landscape phones (don't let a tall
-       min-height push the booking row back below the fold). */
-    min-height: 0;
   }
 }
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,15 +14,19 @@
       <div class="poster__wash" aria-hidden="true"></div>
       <div class="poster__scrim" aria-hidden="true"></div>
 
-      <p class="poster__eyebrow">
-        <span class="poster__prompt" aria-hidden="true">~$ whoami</span>
-        <span class="poster__roles" data-typewriter>{{ $.Site.Params.Subtitle }}</span><span class="poster__cursor" aria-hidden="true"></span>
-      </p>
+      {{/* The frame bleeds full-width; this inner column stays pinned to the
+           53rem content grid so the name aligns with the header and board. */}}
+      <div class="poster__inner">
+        <p class="poster__eyebrow">
+          <span class="poster__prompt" aria-hidden="true">~$ whoami</span>
+          <span class="poster__roles" data-typewriter>{{ $.Site.Params.Subtitle }}</span><span class="poster__cursor" aria-hidden="true"></span>
+        </p>
 
-      <div class="poster__id">
-        <h1 class="poster__name">{{ $home.name | default $.Site.Title }}</h1>
-        {{ with $home.nickname }}<span class="poster__alias">“{{ . }}”</span>{{ end }}
-        {{ with $home.connect.tagline }}<p class="poster__tagline">{{ . }}</p>{{ end }}
+        <div class="poster__id">
+          <h1 class="poster__name">{{ $home.name | default $.Site.Title }}</h1>
+          {{ with $home.nickname }}<span class="poster__alias">“{{ . }}”</span>{{ end }}
+          {{ with $home.connect.tagline }}<p class="poster__tagline">{{ . }}</p>{{ end }}
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## What

The hero already spanned the full content column and aligned perfectly with the header/nav — so this redesigns it to be **full-bleed**: the poster breaks out of the centred 53rem column to span the entire viewport, while the page chrome (header, board, writing) stays in the column. The hero text is pinned back to the content grid so it stays aligned with the header logo and the board below.

## How

- **Breakout:** `.poster` uses `margin: 0 calc(50% - 50vw)` to widen the flex item to the full viewport. `body` gets `overflow-x: clip` so a 100vw child can never spawn a horizontal scrollbar (scrollbar-safe, and `clip` keeps normal vertical scroll without creating a scroll container).
- **Column-pinned content:** a new `.poster__inner` wrapper (`max-width: 53rem; margin-inline: auto`, same side padding as `.container.center`) holds the eyebrow + identity block. The eyebrow and name now sit in a flex column (eyebrow top, name bottom) instead of absolute overlays, so they inherit the column padding at every breakpoint.
- **Height:** the frame is now viewport-driven (`clamp(...)`) rather than a fixed aspect-ratio, which would balloon on ultra-wide monitors now that width is the whole viewport.

## Verification

Rendered headless (Chrome) at 1920 / 1280 / 768 / 390px:

| width | frame spans | hero text left | logo left | board left | h-overflow |
|------|------------|----------------|-----------|------------|------------|
| 1920 | 0→1920 | 568 | 568 | 568 | none |
| 1280 | 0→1280 | 248 | 248 | 248 | none |
| 768  | 0→768  | 32  | 32  | 32  | none |
| 390  | 0→390  | 24  | 24  | 24  | none |

Frame is full-viewport at every size, hero text aligns pixel-for-pixel with the logo and board, and there is no horizontal overflow. Production `hugo` build is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)